### PR TITLE
feat(stemmer): adds english stemmer

### DIFF
--- a/src/tokenizer/stemmer/en.ts
+++ b/src/tokenizer/stemmer/en.ts
@@ -1,0 +1,189 @@
+const step2List = {
+  ational: "ate",
+  tional: "tion",
+  enci: "ence",
+  anci: "ance",
+  izer: "ize",
+  bli: "ble",
+  alli: "al",
+  entli: "ent",
+  eli: "e",
+  ousli: "ous",
+  ization: "ize",
+  ation: "ate",
+  ator: "ate",
+  alism: "al",
+  iveness: "ive",
+  fulness: "ful",
+  ousness: "ous",
+  aliti: "al",
+  iviti: "ive",
+  biliti: "ble",
+  logi: "log",
+};
+
+const step3List = {
+  icate: "ic",
+  ative: "",
+  alize: "al",
+  iciti: "ic",
+  ical: "ic",
+  ful: "",
+  ness: "",
+};
+
+// Consonant
+const c = "[^aeiou]";
+// Vowel
+const v = "[aeiouy]";
+// Consonant sequence
+const C = c + "[^aeiouy]*";
+// Vowel sequence
+const V = v + "[aeiou]*";
+
+// [C]VC... is m>0
+const mgr0 = "^(" + C + ")?" + V + C;
+// [C]VC[V] is m=1
+const meq1 = "^(" + C + ")?" + V + C + "(" + V + ")?$";
+// [C]VCVC... is m>1
+const mgr1 = "^(" + C + ")?" + V + C + V + C;
+// vowel in stem
+const s_v = "^(" + C + ")?" + v;
+
+export function stem(w: string): string {
+  let stem: string;
+  let suffix: string;
+  let re: RegExp;
+  let re2: RegExp;
+  let re3: RegExp;
+  let re4: RegExp;
+
+  if (w.length < 3) {
+    return w;
+  }
+
+  const firstch = w.substring(0, 1);
+  if (firstch == "y") {
+    w = firstch.toUpperCase() + w.substring(1);
+  }
+
+  re = /^(.+?)(ss|i)es$/;
+  re2 = /^(.+?)([^s])s$/;
+
+  if (re.test(w)) {
+    w = w.replace(re, "$1$2");
+  } else if (re2.test(w)) {
+    w = w.replace(re2, "$1$2");
+  }
+
+  re = /^(.+?)eed$/;
+  re2 = /^(.+?)(ed|ing)$/;
+  if (re.test(w)) {
+    const fp = re.exec(w)!;
+    re = new RegExp(mgr0);
+    if (re.test(fp[1])) {
+      re = /.$/;
+      w = w.replace(re, "");
+    }
+  } else if (re2.test(w)) {
+    const fp = re2.exec(w)!;
+    stem = fp[1];
+    re2 = new RegExp(s_v);
+    if (re2.test(stem)) {
+      w = stem;
+      re2 = /(at|bl|iz)$/;
+      re3 = new RegExp("([^aeiouylsz])\\1$");
+      re4 = new RegExp("^" + C + v + "[^aeiouwxy]$");
+      if (re2.test(w)) {
+        w = w + "e";
+      } else if (re3.test(w)) {
+        re = /.$/;
+        w = w.replace(re, "");
+      } else if (re4.test(w)) {
+        w = w + "e";
+      }
+    }
+  }
+
+  re = /^(.+?)y$/;
+  if (re.test(w)) {
+    const fp = re.exec(w)!;
+    stem = fp?.[1];
+    re = new RegExp(s_v);
+    if (stem && re.test(stem)) {
+      w = stem + "i";
+    }
+  }
+
+  re =
+    /^(.+?)(ational|tional|enci|anci|izer|bli|alli|entli|eli|ousli|ization|ation|ator|alism|iveness|fulness|ousness|aliti|iviti|biliti|logi)$/;
+  if (re.test(w)) {
+    const fp = re.exec(w)!;
+    stem = fp?.[1];
+    suffix = fp?.[2];
+    re = new RegExp(mgr0);
+    if (stem && re.test(stem)) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      w = stem + step2List[suffix];
+    }
+  }
+
+  re = /^(.+?)(icate|ative|alize|iciti|ical|ful|ness)$/;
+  if (re.test(w)) {
+    const fp = re.exec(w)!;
+    stem = fp?.[1];
+    suffix = fp?.[2];
+    re = new RegExp(mgr0);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    if (stem && re.test(stem)) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      w = stem + step3List[suffix];
+    }
+  }
+
+  re = /^(.+?)(al|ance|ence|er|ic|able|ible|ant|ement|ment|ent|ou|ism|ate|iti|ous|ive|ize)$/;
+  re2 = /^(.+?)(s|t)(ion)$/;
+  if (re.test(w)) {
+    const fp = re.exec(w)!;
+    stem = fp?.[1];
+    re = new RegExp(mgr1);
+    if (stem && re.test(stem)) {
+      w = stem;
+    }
+  } else if (re2.test(w)) {
+    const fp = re2.exec(w)!;
+    stem = fp?.[1] ?? "" + fp?.[2] ?? "";
+    re2 = new RegExp(mgr1);
+    if (re2.test(stem)) {
+      w = stem;
+    }
+  }
+
+  re = /^(.+?)e$/;
+  if (re.test(w)) {
+    const fp = re.exec(w)!;
+    stem = fp?.[1];
+    re = new RegExp(mgr1);
+    re2 = new RegExp(meq1);
+    re3 = new RegExp("^" + C + v + "[^aeiouwxy]$");
+    if (stem && (re.test(stem) || (re2.test(stem) && !re3.test(stem)))) {
+      w = stem;
+    }
+  }
+
+  re = /ll$/;
+  re2 = new RegExp(mgr1);
+  if (re.test(w) && re2.test(w)) {
+    re = /.$/;
+    w = w.replace(re, "");
+  }
+
+  if (firstch == "y") {
+    w = firstch.toLowerCase() + w.substring(1);
+  }
+
+  return w;
+}

--- a/src/tokenizer/stemmer/index.ts
+++ b/src/tokenizer/stemmer/index.ts
@@ -1,0 +1,14 @@
+import { stem as ENStemmer } from "./en";
+import { Language } from "../languages";
+
+type Stemmer = (word: string) => string;
+
+type StemmerMap = {
+  [key in Language]: Stemmer;
+};
+
+export const stemmers: Partial<StemmerMap> = {
+  english: ENStemmer,
+};
+
+export const availableStemmers = Object.keys(stemmers);

--- a/tap-snapshots/tests/lyra.dataset.test.ts.test.cjs
+++ b/tap-snapshots/tests/lyra.dataset.test.ts.test.cjs
@@ -7,7 +7,7 @@
 'use strict'
 exports[`tests/lyra.dataset.test.ts TAP lyra.dataset should perform paginate search > should perform paginate search-page-1 1`] = `
 Object {
-  "count": 2240,
+  "count": 2357,
   "elapsed": 0n,
   "hits": Array [
     Object {
@@ -83,6 +83,16 @@ Object {
     Object {
       "categories": Object {
         "first": "By place",
+        "second": "Egypt",
+      },
+      "date": "-276",
+      "description": "The first of the Syrian Wars starts between Egypt's Ptolemy II and Seleucid emperor Antiochus I Soter. The Egyptians invade northern Syria, but Antiochus defeats and repels his opponent's army.",
+      "granularity": "year",
+      "id": "",
+    },
+    Object {
+      "categories": Object {
+        "first": "By place",
         "second": "Seleucid Empire",
       },
       "date": "-272",
@@ -100,6 +110,15 @@ Object {
       "granularity": "year",
       "id": "",
     },
+  ],
+}
+`
+
+exports[`tests/lyra.dataset.test.ts TAP lyra.dataset should perform paginate search > should perform paginate search-page-2 1`] = `
+Object {
+  "count": 2357,
+  "elapsed": 0n,
+  "hits": Array [
     Object {
       "categories": Object {
         "first": "By place",
@@ -110,15 +129,6 @@ Object {
       "granularity": "year",
       "id": "",
     },
-  ],
-}
-`
-
-exports[`tests/lyra.dataset.test.ts TAP lyra.dataset should perform paginate search > should perform paginate search-page-2 1`] = `
-Object {
-  "count": 2240,
-  "elapsed": 0n,
-  "hits": Array [
     Object {
       "categories": Object {
         "first": "By place",
@@ -126,6 +136,16 @@ Object {
       },
       "date": "-262",
       "description": "After Athens surrenders following a long siege by Macedonian forces, Antigonus II Gonatas re-garrisons Athens and forbids the city from making war. Otherwise, he leaves Athens alone as the seat of philosophy and learning in Greece.",
+      "granularity": "year",
+      "id": "",
+    },
+    Object {
+      "categories": Object {
+        "first": "By place",
+        "second": "China",
+      },
+      "date": "-260",
+      "description": "In the Battle of Changping, the army of the Qin state routs the army of Zhao, establishing its military superiority over all other Chinese states during the Warring States Period. The battle, in which Zhao forces are led by Lian Po and Zhao Kuo, while Qin is led by Wang He and Bai Qi, takes place near modern-day Gaoping in Shanxi and hundreds of thousands of soldiers from Zhao are executed after the battle.",
       "granularity": "year",
       "id": "",
     },
@@ -199,6 +219,15 @@ Object {
       "granularity": "year",
       "id": "",
     },
+  ],
+}
+`
+
+exports[`tests/lyra.dataset.test.ts TAP lyra.dataset should perform paginate search > should perform paginate search-page-3 1`] = `
+Object {
+  "count": 2357,
+  "elapsed": 0n,
+  "hits": Array [
     Object {
       "categories": Object {
         "first": "By place",
@@ -219,15 +248,6 @@ Object {
       "granularity": "year",
       "id": "",
     },
-  ],
-}
-`
-
-exports[`tests/lyra.dataset.test.ts TAP lyra.dataset should perform paginate search > should perform paginate search-page-3 1`] = `
-Object {
-  "count": 2240,
-  "elapsed": 0n,
-  "hits": Array [
     Object {
       "categories": Object {
         "first": "By place",
@@ -305,26 +325,6 @@ Object {
       },
       "date": "-240",
       "description": "Two of Carthage's mercenary commanders ampampndash Spendius and Mathos ampampndash convince the Libyan conscripts in the mercenary army, that is currently occupying the Carthaginian city of Tunis, to accept their leadership. They persuade the native Libyans that Carthage will take revenge against them for their part in the conflict once the foreign mercenaries are paid and sent home. They then convince the combined mercenary armies to revolt against Carthage and convince the various native Libyan towns and cities to back the revolt. Spendius and Mathos then take the Carthaginian commander Gesco as a hostage. What has started as an argument over pay owed to soldiers by the Carthaginian Government, explodes into a full-scale revolution, known as the Mercenary War.",
-      "granularity": "year",
-      "id": "",
-    },
-    Object {
-      "categories": Object {
-        "first": "By place",
-        "second": "Carthage",
-      },
-      "date": "-239",
-      "description": "Concerned that Hamilcar Barca's leniency in pardoning those who he has captured who have participated in the Mercenary War will encourage others to defect, Mathos and Spendius order the mutilation and execution of ampquotabout seven hundredampquot Carthaginian prisoners, including Gesco. With the mercenaries jointly guilty of these atrocities, defectors dare not face Carthaginian justice under Hamilcar.",
-      "granularity": "year",
-      "id": "",
-    },
-    Object {
-      "categories": Object {
-        "first": "By place",
-        "second": "Carthage",
-      },
-      "date": "-238",
-      "description": "The Carthaginian armies besiege and capture Utica and Hippacritae. This ends the Carthaginian civil war.",
       "granularity": "year",
       "id": "",
     },

--- a/tap-snapshots/tests/tokenizer.test.ts.test.cjs
+++ b/tap-snapshots/tests/tokenizer.test.ts.test.cjs
@@ -29,9 +29,9 @@ Array [
   "quick",
   "brown",
   "fox",
-  "jumps",
+  "jump",
   "over",
-  "lazy",
+  "lazi",
   "dog",
 ]
 `
@@ -39,27 +39,27 @@ Array [
 exports[`tests/tokenizer.test.ts TAP Tokenizer Should tokenize and stem correctly in english > Should tokenize and stem correctly in english-O2 1`] = `
 Array [
   "i",
-  "baked",
+  "bake",
   "some",
-  "cakes",
+  "cake",
 ]
 `
 
 exports[`tests/tokenizer.test.ts TAP Tokenizer Should tokenize and stem correctly in english and allow duplicates > Should tokenize and stem correctly in english and allow duplicates-O1 1`] = `
 Array [
-  "this",
+  "thi",
   "is",
   "a",
   "test",
   "with",
-  "duplicates",
+  "duplic",
 ]
 `
 
 exports[`tests/tokenizer.test.ts TAP Tokenizer Should tokenize and stem correctly in english and allow duplicates > Should tokenize and stem correctly in english and allow duplicates-O2 1`] = `
 Array [
-  "it's",
-  "alive",
+  "it'",
+  "aliv",
 ]
 `
 

--- a/tests/lyra.test.ts
+++ b/tests/lyra.test.ts
@@ -132,8 +132,8 @@ t.test("lyra", t => {
     const result1 = search(db, { term: "fox", exact: true });
     const result2 = search(db, { term: "dog", exact: true });
 
-    t.equal(result1.count, 1);
-    t.equal(result2.count, 2);
+    t.equal(result1.count, 2);
+    t.equal(result2.count, 3);
 
     // Prefix search
     const result3 = search(db, { term: "fox", exact: false });
@@ -146,7 +146,7 @@ t.test("lyra", t => {
     const result5 = search(db, { term: "fx", tolerance: 1 });
     const result6 = search(db, { term: "dg", tolerance: 2 });
 
-    t.equal(result5.count, 1);
+    t.equal(result5.count, 2);
     t.equal(result6.count, 4);
   });
 

--- a/tests/stemmer.en.test.ts
+++ b/tests/stemmer.en.test.ts
@@ -1,0 +1,25 @@
+import t from "tap";
+import { stem } from "../src/tokenizer/stemmer/en";
+
+t.test("ensligh stemmer", t => {
+  t.plan(1);
+
+  t.test("should correctly stem words", t => {
+    t.plan(14);
+
+    t.equal(stem("cats"), "cat");
+    t.equal(stem("cars"), "car");
+    t.equal(stem("beautiful"), "beauti");
+    t.equal(stem("compressing"), "compress");
+    t.equal(stem("inception"), "incep");
+    t.equal(stem("searching"), "search");
+    t.equal(stem("outragious"), "outragi");
+    t.equal(stem("yelling"), "yell");
+    t.equal(stem("overseed"), "overse");
+    t.equal(stem("hopefully"), "hopefulli");
+    t.equal(stem("mindfullness"), "mindful");
+    t.equal(stem("mindfullness"), "mindful");
+    t.equal(stem("chill"), "chill");
+    t.equal(stem("rational"), "ration");
+  });
+});


### PR DESCRIPTION
This PR aims to add an English stemmer to Lyra.
The API is designed in such a way that if a stemmer is not available for a selected language, the stemming process will be skipped.

The stemming algorithm is based on the following paper: http://www.tartarus.org/~martin/PorterStemmer.