### PR TITLE
fix: replace setImmediate with setTimeout

### DIFF
--- a/src/lyra.ts
+++ b/src/lyra.ts
@@ -433,10 +433,10 @@ export async function insertBatch<S extends PropertiesSchema>(
         }
       }
 
-      setImmediate(insertBatch);
+      setTimeout(insertBatch, 0);
     }
 
-    setImmediate(insertBatch);
+    setTimeout(insertBatch, 0);
   });
 }
 


### PR DESCRIPTION
Currently, the `batchInsert` function uses `setImmediate` to schedule the recursive `insert` calls to avoid blocking the event loop.

However, this causes the API to break in the browsers where `setImmediate` is not defined as it's a Node API.

This PR fixes that issue by using `setTimeout` with a delay of `0`.

cc// @micheleriva 