### PR TITLE
fix(insertion-checker): fix crash when warning on react-native

### DIFF
--- a/src/insertion-checker.ts
+++ b/src/insertion-checker.ts
@@ -1,7 +1,8 @@
 const kInsertions = Symbol("lyra.insertions");
 
 const warn =
-  "process" in globalThis
+  // Web platforms don't have process. React-Native doesn't have process.emitWarning.
+  "process" in globalThis && process.emitWarning !== undefined
     ? process.emitWarning
     : function emitWarning(message: string, options: { code: string }) {
         console.warn(`[WARNING] [${options.code}] ${message}`);

--- a/src/insertion-checker.ts
+++ b/src/insertion-checker.ts
@@ -1,12 +1,11 @@
 const kInsertions = Symbol("lyra.insertions");
 
+// Web platforms don't have process. React-Native doesn't have process.emitWarning.
 const warn =
-  // Web platforms don't have process. React-Native doesn't have process.emitWarning.
-  "process" in globalThis && process.emitWarning !== undefined
-    ? process.emitWarning
-    : function emitWarning(message: string, options: { code: string }) {
-        console.warn(`[WARNING] [${options.code}] ${message}`);
-      };
+  globalThis.process?.emitWarning ??
+  function emitWarning(message: string, options: { code: string }) {
+    console.warn(`[WARNING] [${options.code}] ${message}`);
+  };
 
 export function trackInsertion(_lyra: unknown) {
   const lyra = _lyra as object & { [kInsertions]?: number };


### PR DESCRIPTION
Fixes a crash when running on React-Native which does have `process` but not `process.emitWarning`.