### PR TITLE
chore(package): remove broken npm run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "format": "prettier --write \"**/*.{ts,js}\"",
     "lint": "pnpm run format && eslint . --ext .js,.ts",
     "prepare": "husky install",
-    "benchmark": "pnpm build:lyra && node ./benchmarks/index.js",
-    "build:lyra": "cd packages/lyra && pnpm build",
     "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:module": "tsc --project tsconfig.esm.json",
     "build:browser": "tsc --project tsconfig.browser.json",


### PR DESCRIPTION
part of #117 that removes broken npm run scripts that appear to have been left over from when this was a monorepo