### PR TITLE
build(package): builds the package on prepare, allowing for git dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "commit": "pnpm lint-staged && cz",
     "format": "prettier --write \"**/*.{ts,js}\"",
     "lint": "pnpm run format && eslint . --ext .js,.ts",
-    "prepare": "husky install",
+    "prepare": "husky install && pnpm build",
     "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:module": "tsc --project tsconfig.esm.json",
     "build:browser": "tsc --project tsconfig.browser.json",


### PR DESCRIPTION
As noted in the [npm docs](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts), if a package has a `prepare` script, it will be executed before packaging when installing directly from git or github.

**This allows `npm install LyraSearch/lyra` directly as a GitHub URL in consuming packages.** It also allows `npm install git+https://github.com/LyraSearch/lyra.git`. Without this change, the `dist` folder will not be installed when installing from git or github.

**This allows consuming packages to install the latest from main, during development instead of waiting for a release**  🎉 

**Note:** This begs the question if the `build` script should be using `pnpm`. I think a follow-up PR is merited to use `npm` directly for `build` and `prepare` scripts, making the package as devex friendly as possible when consumed by npm. That begs the question of why we use `pnpm` at all. The above use case will not have a fixed npm `package-lock.json` and the transient deps will not be guaranteed. Perhaps that merits a follow up issue for further discussion.