### PR TITLE
feat(lyra): compute levenshtein metric within a given tolerance

### DIFF
--- a/src/levenshtein.ts
+++ b/src/levenshtein.ts
@@ -1,3 +1,141 @@
+type BoundedMetric = {
+  isBounded: boolean;
+  distance: number;
+}
+
+/**
+ * Computes the Levenshtein distance between two strings (a, b), returning early with -1 if the distance
+ * is greater than the given tolerance.
+ * It assumes that:
+ * - tolerance >= ||a| - |b|| >= 0
+ */
+export function boundedLevenshtein(a: string, b: string, tolerance: number): BoundedMetric {
+  const distance = _boundedLevenshtein(a, b, tolerance);
+  return {
+    distance,
+    isBounded: distance >= 0,
+  };
+}
+
+/**
+ * Inspired by:
+ * https://github.com/Yomguithereal/talisman/blob/86ae55cbd040ff021d05e282e0e6c71f2dde21f8/src/metrics/levenshtein.js#L218-L340
+ */
+function _boundedLevenshtein(a: string, b: string, tolerance: number): number {
+  // the strings are the same
+  if (a === b) {
+    return 0;
+  }
+
+  // a should be the shortest string
+  let swap = a;
+  if (a.length > b.length) {
+    a = b;
+    b = swap;
+  }
+
+  let lenA = a.length;
+  let lenB = b.length;
+
+  // ignore common suffix
+  // note: `~-` decreases by a unit in a bitwise fashion
+  while (lenA > 0 && (a.charCodeAt(~-lenA) === b.charCodeAt(~-lenB))) {
+    lenA--;
+    lenB--;
+  }
+
+  // early return when the smallest string is empty
+  if (!lenA) {
+    return lenB > tolerance ? -1 : lenB;
+  }
+
+  // ignore common prefix
+  let startIdx = 0;
+  while (startIdx < lenA && (a.charCodeAt(startIdx) === b.charCodeAt(startIdx))) {
+    startIdx++;
+  }
+  lenA -= startIdx;
+  lenB -= startIdx;
+
+  // early return when the smallest string is empty
+  if (lenA === 0) {
+    return lenB > tolerance ? -1 : lenB;
+  }
+
+  const delta = lenB - lenA;
+
+  if (tolerance > lenB) {
+    tolerance = lenB;
+  } else if (delta > tolerance) {
+    return -1;
+  }
+
+  let i = 0;
+  const row = [];
+  const characterCodeCache = [];
+
+  while (i < tolerance) {
+    characterCodeCache[i] = b.charCodeAt(startIdx + i);
+    row[i] = ++i;
+  }
+
+  while (i < lenB) {
+    characterCodeCache[i] = b.charCodeAt(startIdx + i);
+    row[i++] = tolerance + 1;
+  }
+
+  const offset = tolerance - delta;
+  const haveMax = tolerance < lenB;
+
+  let jStart = 0;
+  let jEnd = tolerance;
+
+  let current = 0;
+  let left = 0;
+  let above = 0;
+  let charA = 0;
+  let j = 0;
+
+  // Starting the nested loops
+  for (i = 0; i < lenA; i++) {
+    left = i;
+    current = i + 1;
+
+    charA = a.charCodeAt(startIdx + i);
+    jStart += (i > offset) ? 1 : 0;
+    jEnd += (jEnd < lenB) ? 1 : 0;
+
+    for (j = jStart; j < jEnd; j++) {
+      above = current;
+
+      current = left;
+      left = row[j];
+
+      if (charA !== characterCodeCache[j]) {
+        // insert current
+        if (left < current) {
+          current = left;
+        }
+
+        // delete current
+        if (above < current) {
+          current = above;
+        }
+
+        current++;
+      }
+
+      row[j] = current;
+    }
+
+    if (haveMax && row[i + delta] > tolerance) {
+      return -1;
+    }
+  }
+
+  return current <= tolerance ? current : -1;
+} 
+
 export function levenshtein(a: string, b: string): number {
   /* c8 ignore next 3 */
   if (!a.length) {
@@ -9,12 +147,10 @@ export function levenshtein(a: string, b: string): number {
     return a.length;
   }
 
-  let tmp;
-
+  let swap = a;
   if (a.length > b.length) {
-    tmp = a;
     a = b;
-    b = tmp;
+    b = swap;
   }
 
   const row = Array.from({ length: a.length + 1 }, (_, i) => i);

--- a/src/prefix-tree/trie.ts
+++ b/src/prefix-tree/trie.ts
@@ -1,5 +1,5 @@
 import { create as createNode, removeDocument, updateParent, Node } from "./node";
-import { levenshtein } from "../levenshtein";
+import { boundedLevenshtein } from "../levenshtein";
 
 export type Nodes = Record<string, Node>;
 
@@ -24,9 +24,9 @@ function findAllWords(nodes: Nodes, node: Node, output: FindResult, term: string
         // computing the absolute difference of letters between the term and the word
         const difference = Math.abs(term.length - word.length);
 
-        // if the tolerance is set, we need to calculate the distance using levenshtein algorithm
-        // if the distance is greater than the tolerance, we don't need to add the word to the output
-        if (difference <= tolerance && levenshtein(term, word) <= tolerance) {
+        // if the tolerance is set, check whether the edit distance is within tolerance.
+        // In that case, we don't need to add the word to the output
+        if (difference <= tolerance && boundedLevenshtein(term, word, tolerance).isBounded) {
           output[word] = [];
         }
       } else {

--- a/tests/levenshtein.test.ts
+++ b/tests/levenshtein.test.ts
@@ -1,0 +1,66 @@
+import t from "tap";
+import { levenshtein, boundedLevenshtein } from "../src/levenshtein";
+
+t.test("levenshtein", t => {
+  t.plan(3);
+
+  t.test("should be 0 when both inputs are empty", t => {
+    t.plan(1);
+    
+    t.equal(levenshtein("", ""), 0);
+  })
+
+  t.test("should be the max input length when either strings are empty", t => {
+    t.plan(2);
+    
+    t.equal(levenshtein("", "some"), 4);
+    t.equal(levenshtein("body", ""), 4);
+  })
+
+  t.test("some examples", t => {
+    t.plan(5);
+    
+    t.equal(levenshtein("aa", "b"), 2);
+    t.equal(levenshtein("b", "aa"), 2);
+    t.equal(levenshtein("somebody once", "told me"), 9);
+    t.equal(levenshtein("the world is gonna", "roll me"), 15);
+    t.equal(levenshtein("kaushuk chadhui", "caushik chakrabar"), 8);
+  })
+});
+
+t.test("boundedLevenshtein", t => {
+  t.plan(4);
+
+  t.test("should be 0 when both inputs are empty", t => {
+    t.plan(2);
+    
+    t.match(boundedLevenshtein("", "", 0), { distance: 0, isBounded: true });
+    t.match(boundedLevenshtein("", "", 1), { distance: 0, isBounded: true });
+  })
+
+  t.test("should be the max input length when either strings are empty", t => {
+    t.plan(2);
+
+    t.match(boundedLevenshtein("", "some", 4), { distance: 4, isBounded: true });
+    t.match(boundedLevenshtein("body", "", 4), { distance: 4, isBounded: true });
+  })
+
+  t.test("distance should be the same as levenshtein, when tolerance is high enough", t => {
+    t.plan(5);
+
+    const tol = 15;
+    
+    t.equal(levenshtein("aa", "b"), boundedLevenshtein("aa", "b", tol).distance);
+    t.equal(levenshtein("b", "aa"), boundedLevenshtein("bb", "a", tol).distance);
+    t.equal(levenshtein("somebody once", "told me"), boundedLevenshtein("somebody once", "told me", tol).distance);
+    t.equal(levenshtein("the world is gonna", "roll me"), boundedLevenshtein("the world is gonna", "roll me", tol).distance);
+    t.equal(levenshtein("kaushuk chadhui", "caushik chakrabar"), boundedLevenshtein("kaushuk chadhui", "caushik chakrabar", tol).distance);
+  })
+
+  t.test("should tell whether the Levenshtein distance is upperbounded by a given tolerance", t => {
+    t.plan(2);
+
+    t.match(boundedLevenshtein("somebody once", "told me", 9), { isBounded: true });
+    t.match(boundedLevenshtein("somebody once", "told me", 8), { isBounded: false });
+  })
+});


### PR DESCRIPTION
As discussed privately, I have noticed that the `levenshtein` distance is currently only used as a comparison metric to check whether two strings have edit distance less than a given `tolerance` threshold.

Computing the `levenshtein` metric in the general case takes time `O(max(m, n))` and space `O(max(m, n))`, where `m` and `n` is the length of the two input strings. When we're only interested in retrieving the exact edit distance when it's below or equal to a given `tolerance` threshold, more time-efficient methods exist.

Given

```ts
let term: string;
let word: string;
let tolerance: number; // small, non-negative integer
```

this PR turns the comparison

```ts
if (levenshtein(term, word) <= tolerance) {
  // ...
}
```

into the following:

```ts
if (boundedLevenshtein(term, word, tolerance).isBounded) {
  // ...
}
```

The core algorithm this PR takes inspiration from has already been developed in the [`talisman`](https://github.com/Yomguithereal/talisman/blob/86ae55cbd040ff021d05e282e0e6c71f2dde21f8/src/metrics/levenshtein.js#L218-L340) project, which is MIT licensed.

It'd be interested to see how the changes introduced by this PR will influence the benchmarks. I expect a marginal performance increase as the size of the inputs grows.

## Alternative not considered in this PR

As the size of the input scales, computing an exact comparison metric may not be needed. Luckily, the literature offers a plethora of polylogarithmic approximation algorithms to choose from. Should you be interested in this slightly less precise alternative, I'd suggest to take a look at [Andoni *et al.*](https://onak.pl/papers/focs_2010-approximating_edit_distance.html)'s method.