### PR TITLE
feat(tokenizer): adds basic ngram algorithm

### DIFF
--- a/src/tokenizer/ngram.ts
+++ b/src/tokenizer/ngram.ts
@@ -1,0 +1,15 @@
+export function nGram(text: string, size = 3): string[] {
+  const ngrams: string[] = [];
+
+  for (let i = 0; i < text.length - (size - 1); i++) {
+    const substr: string[] = [];
+
+    for (let j = 0; j < size; j++) {
+      substr.push(text[i + j]);
+    }
+
+    ngrams.push(substr.join(""));
+  }
+
+  return ngrams;
+}

--- a/tests/ngram.test.ts
+++ b/tests/ngram.test.ts
@@ -1,0 +1,14 @@
+import t from "tap";
+import { nGram } from "../src/tokenizer/ngram";
+
+t.test("ngram", t => {
+  t.plan(1);
+
+  t.test("should correctly split text into ngrams of a given size", t => {
+    t.plan(3);
+
+    t.same(nGram("hello", 2), ["he", "el", "ll", "lo"]);
+    t.same(nGram("quick", 3), ["qui", "uic", "ick"]);
+    t.same(nGram("terence", 4), ["tere", "eren", "renc", "ence"]);
+  });
+});


### PR DESCRIPTION
This PR aims to add an `n-gram` tokenization step to Lyra.

Using the `tests/datasets/events.json` dataset, shows that the total index size increases by around 7% when using a `trigram` (in JSON, from 41MB to 44MB). This number could decrease once we implement the direct acyclic graph data structure for storing the data.