### PR TITLE
feat(lyra): implement numbers and booleans as searchable

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -24,8 +24,8 @@ export function CANT_DELETE_DOC_NOT_FOUND(id: string): string {
   return `Document with ID ${id} does not exist.`;
 }
 
-export function CANT_DELETE_DOCUMENT(docID: string, key: string, token: string): string {
-  return `Unable to delete document "${docID}" from index "${key}" on word "${token}".`;
+export function CANT_DELETE_DOCUMENT(docID: string, key: string, token: string | number | boolean): string {
+  return `Unable to delete document "${docID}" from index "${key}" on word "${token.toString()}".`;
 }
 
 export function UNSUPPORTED_NESTED_PROPERTIES(): string {

--- a/src/prefix-tree/trie.ts
+++ b/src/prefix-tree/trie.ts
@@ -20,7 +20,7 @@ function findAllWords(nodes: Nodes, node: Node, output: FindResult, term: string
     }
 
     if (!(word in output)) {
-      // With non-string terms, we can't user levenshtein distance
+      // With non-string terms, we can't use levenshtein distance
       if (typeof term !== "string") {
         return;
       }

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -4,11 +4,11 @@ import { defaultTokenizerConfig } from "../lyra";
 import { replaceDiacritics } from "./diacritics";
 
 export type Tokenizer = (
-  text: string,
+  text: string | number | boolean,
   language: Language,
   allowDuplicates: boolean,
   tokenizerConfig: TokenizerConfig,
-) => string[];
+) => string[] | number[] | boolean[];
 
 const splitRegex: Record<Language, RegExp> = {
   dutch: /[^a-z0-9_'-]+/gim,
@@ -70,14 +70,14 @@ function normalizeToken(token: string, language: Language, tokenizerConfig: Toke
 }
 
 export function tokenize(
-  input: string,
+  input: string | number | boolean,
   language: Language = "english",
   allowDuplicates = false,
   tokenizerConfig: TokenizerConfig = defaultTokenizerConfig(language),
-) {
+): string[] | number[] | boolean[] {
   /* c8 ignore next 3 */
   if (typeof input !== "string") {
-    return [input];
+    return [input] as number[] | boolean[];
   }
 
   const splitRule = splitRegex[language];

--- a/tests/lyra.test.ts
+++ b/tests/lyra.test.ts
@@ -111,7 +111,7 @@ t.test("checkInsertDocSchema", t => {
 });
 
 t.test("lyra", t => {
-  t.plan(16);
+  t.plan(17);
 
   t.test("should correctly search for data", t => {
     t.plan(6);
@@ -630,6 +630,54 @@ t.test("lyra", t => {
 
     t.rejects(insertBatch(db, wrongSchemaDocs));
   });
+
+  t.test("Should support schema properties types as searched term", t => {
+    t.plan(6);
+
+    const db = create({
+      schema: {
+        author: "string",
+        quote: "string",
+        isFavorite: "boolean",
+        rating: "number",
+      },
+    });
+
+    insert(db, {
+      author: "Oscar Wilde",
+      quote: "Be yourself; everyone else is already taken.",
+      isFavorite: true,
+      rating: 4,
+    });
+
+    insert(db, {
+      author: "Frank Zappa",
+      quote: "So many books, so little time.",
+      isFavorite: false,
+      rating: 3,
+    });
+
+    insert(db, {
+      author: "Albert Einstein",
+      quote: "We cannot solve problems with the kind of thinking we employed when we came up with them.",
+      isFavorite: true,
+      rating: 5,
+    });
+
+    const searchBoolean = search(db, { term: true });
+    const searchBooleanWithProperties = search(db, { term: true, properties: ["isFavorite"] });
+    const searchBooleanWithProperties2 = search(db, { term: true, properties: ["author"] });
+    t.equal(searchBoolean.count, 2);
+    t.equal(searchBooleanWithProperties.count, 2);
+    t.equal(searchBooleanWithProperties2.count, 0);
+
+    const searchNumber = search(db, { term: 3 });
+    const searchNumberWithProperties = search(db, { term: 3, properties: ["rating"] });
+    const searchNumberWithProperties2 = search(db, { term: 3, properties: ["author"] });
+    t.equal(searchNumber.count, 1);
+    t.equal(searchNumberWithProperties.count, 1);
+    t.equal(searchNumberWithProperties2.count, 0);
+  });
 });
 
 t.test("lyra - hooks", t => {
@@ -686,7 +734,7 @@ t.test("custom tokenizer configuration", t => {
         txt: "string",
       },
       tokenizer: {
-        tokenizerFn: text => text.split(","),
+        tokenizerFn: text => text.toString().split(","),
       },
     });
 

--- a/tests/lyra.test.ts
+++ b/tests/lyra.test.ts
@@ -645,21 +645,21 @@ t.test("lyra", t => {
 
     insert(db, {
       author: "Oscar Wilde",
-      quote: "Be yourself; everyone else is already taken.",
+      quote: "Be yourself; everyone else is already taken. It's true.",
       isFavorite: true,
       rating: 4,
     });
 
     insert(db, {
       author: "Frank Zappa",
-      quote: "So many books, so little time.",
+      quote: "So many books like 3, so little time.",
       isFavorite: false,
       rating: 3,
     });
 
     insert(db, {
       author: "Albert Einstein",
-      quote: "We cannot solve problems with the kind of thinking we employed when we came up with them.",
+      quote: "We cannot solve problems with the kind of thinking we employed when we came up with them. True.",
       isFavorite: true,
       rating: 5,
     });


### PR DESCRIPTION
This PR implements #139.

Often we added `numbers` and `booleans` in Lyra's schema. Those columns should be searchable. Non-string nodes were not inserted into the Trie.

https://github.com/LyraSearch/lyra/blob/b1bf7a6080cc8177624122576a7de23b3c8117b1/src/lyra.ts#L225

Now that nodes are inserted but the tokens are not tokenized in the `recursiveTrieInsertion` method.

```js
{
  '60440268-3': {
    id: '60440268-3',
    key: 't',
    word: 't',
    parent: '60440268-0',
    children: { r: '60440268-4' },
    docs: [],
    end: false
  },
  '60440268-4': {
    id: '60440268-4',
    key: 'r',
    word: 'tr',
    parent: '60440268-3',
    children: { u: '60440268-5' },
    docs: [],
    end: false
  },
  '60440268-5': {
    id: '60440268-5',
    key: 'u',
    word: 'tru',
    parent: '60440268-4',
    children: { e: '60440268-6' },
    docs: [],
    end: false
  },
  '60440268-6': {
    id: '60440268-6',
    key: 'e',
    word: 'true',
    parent: '60440268-5',
    children: {},
    docs: [ '60440268-2' ],
    end: true
  },
  '60440268-7': {
    id: '60440268-7',
    key: '4',
    word: '4',
    parent: '60440268-1',
    children: {},
    docs: [ '60440268-2' ],
    end: true
  }
}
```

I also added a check to not perform the **Levenshtein distance** when the searched term is _non-string_.

The type of the term has been updated allowing the same types supported by the schema.

```bash
-  term: string;
+  term: string | number | boolean;
```