### PR TITLE
diacritics replacer proposal

### DIFF
--- a/src/tokenizer/diacritics.ts
+++ b/src/tokenizer/diacritics.ts
@@ -1,23 +1,24 @@
-const diacritics = [
-  { char: "A", base: /[\300-\306]/g },
-  { char: "a", base: /[\340-\346]/g },
-  { char: "E", base: /[\310-\313]/g },
-  { char: "e", base: /[\350-\353]/g },
-  { char: "I", base: /[\314-\317]/g },
-  { char: "i", base: /[\354-\357]/g },
-  { char: "O", base: /[\322-\330]/g },
-  { char: "o", base: /[\362-\370]/g },
-  { char: "U", base: /[\331-\334]/g },
-  { char: "u", base: /[\371-\374]/g },
-  { char: "N", base: /[\321]/g },
-  { char: "n", base: /[\361]/g },
-  { char: "C", base: /[\307]/g },
-  { char: "c", base: /[\347]/g },
+const DIACRITICS_CHARCODE_START = 192;
+const DIACRITICS_CHARCODE_END = 252;
+
+const CHARCODE_REPLACE_MAPPING = [
+  65, 65, 65, 65, 65, 65, 65, 67, 69, 69, 69,
+  69, 73, 73, 73, 73, null, 78, 79, 79, 79,
+  79, 79, 79, 79, 85, 85, 85, 85, null, null,
+  null, 97, 97, 97, 97, 97, 97, 97, 99, 101,
+  101, 101, 101, 105, 105, 105, 105, null, 110, 111,
+  111, 111, 111, 111, 111, 111, 117, 117, 117, 117
 ];
 
-export function replaceDiacritics(str: string): string {
-  for (const { char, base } of diacritics) {
-    str = str.replace(base, char);
+function replaceChar(charCode: number) : number {
+  if (charCode < DIACRITICS_CHARCODE_START || charCode > DIACRITICS_CHARCODE_END) return charCode;
+  return CHARCODE_REPLACE_MAPPING[charCode - DIACRITICS_CHARCODE_START] || charCode;
+}
+
+export function replaceDiacritics(str: string) : string {
+  const stringCharCode = [];
+  for (let idx = 0; idx < str.length; idx++) {
+    stringCharCode[idx] = replaceChar(str.charCodeAt(idx));
   }
-  return str;
+  return String.fromCharCode(...stringCharCode);
 }


### PR DESCRIPTION
This PR proposes an optimization to tokenizer diacritics replacer mapping substitutes char codes and accesses it straight to its position.

I've compared the current performance and the proposed method:

```javascript
import cronometro from 'cronometro';
import currentReplacer from './current.js';
import proposedReplacer from './proposed.js';

const dataset = [
  'áàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ',
  'áaauioèaíïóiuubnÁoiÃotytÓhygÚnÑ',
  'aaaaeeeiiooooucnAAAAEEIIOOOOUCN'
];

cronometro({
  'current replacer': () => {
    for( const word in dataset) {
      currentReplacer(word)
    }
  },
  'proposed replacer': () => {
    for (const word in dataset) {
      proposedReplacer(word)
    }
  },
})
```

Here are the results:
<img width="539" alt="image" src="https://user-images.githubusercontent.com/51336150/193464012-6d20970b-fbc0-412e-a949-c1fc03f5cb4e.png">


Also tried to compare execution time with:

```javascript
const worstCaseStr = 'áàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ';
const mediumCaseStr = 'áaauioèaíïóiuubnÁoiÃotytÓhygÚnÑ';
const bestCaseStr = 'aaaaeeeiiooooucnAAAAEEIIOOOOUCN';

console.time('measure_current');
for (let i = 0; i < 100000; i++) {
  currentReplacer(worstCaseStr);
  currentReplacer(mediumCaseStr);
  currentReplacer(bestCaseStr);
}
console.timeEnd('measure_current');

console.time('measure_proposed');
for (let i = 0; i < 100000; i++) {
  proposedReplacer(worstCaseStr);
  proposedReplacer(mediumCaseStr);
  proposedReplacer(bestCaseStr);
}
console.timeEnd('measure_proposed');
```

Here are the results:
<img width="240" alt="image" src="https://user-images.githubusercontent.com/51336150/193464409-fb14ef88-49b2-452f-b517-7d7aff8f6432.png">



I think this can help speed up insert operation performance.




