### PR TITLE
Add sideEffects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@lyrasearch/lyra",
   "version": "0.3.1",
   "description": "Fast, in-memory, typo-tolerant, full-text search engine written in TypeScript",
+  "sideEffects": false,
   "main": "./dist/cjs/src/lyra.js",
   "module": "./dist/esm/src/lyra.js",
   "browser": "./dist/browser/src/lyra.js",


### PR DESCRIPTION
By adding side effects = false to the package.json, it enables tree shaking on certain platforms. 
For example, see webpack: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free. 
This of course assumes that the package is completely free of side effects (pure).