### PR TITLE
Store defaultLanguage

### DIFF
--- a/src/lyra.ts
+++ b/src/lyra.ts
@@ -738,13 +738,14 @@ export function save<S extends PropertiesSchema>(lyra: Lyra<S>): Data<S> {
 
 export function load<S extends PropertiesSchema>(
   lyra: Lyra<S>,
-  { index, docs, nodes, schema, frequencies, tokenOccurrencies }: Data<S>,
+  { index, docs, nodes, schema, frequencies, tokenOccurrencies, defaultLanguage }: Data<S>,
 ) {
   if (!lyra.edge) {
     throw new Error(ERRORS.GETTER_SETTER_WORKS_ON_EDGE_ONLY("load"));
   }
 
   lyra.index = index;
+  lyra.defaultLanguage = defaultLanguage;
   lyra.docs = docs;
   lyra.nodes = nodes;
   lyra.schema = schema;

--- a/src/lyra.ts
+++ b/src/lyra.ts
@@ -86,6 +86,7 @@ export type Configuration<S extends PropertiesSchema> = {
 
 export type Data<S extends PropertiesSchema> = {
   docs: Record<string, ResolveSchema<S> | undefined>;
+  defaultLanguage: Language;
   index: Index;
   nodes: Nodes;
   schema: S;
@@ -726,6 +727,7 @@ export function search<S extends PropertiesSchema>(
 export function save<S extends PropertiesSchema>(lyra: Lyra<S>): Data<S> {
   return {
     index: lyra.index,
+    defaultLanguage: lyra.defaultLanguage,
     docs: lyra.docs,
     nodes: lyra.nodes,
     schema: lyra.schema,


### PR DESCRIPTION
The defaultLanguage param is not being saved. As such, when you restore a file from disk that used the Arabic indexer, searches won't work as they default to English. See the second pull request I opened for the data persistence plugin (https://github.com/LyraSearch/plugin-data-persistence/pull/11). Both these changes are needed for the search to work again after a file gets restored.