### PR TITLE
feat(insert): adds custom ID capabilities

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -67,3 +67,11 @@ export function INVALID_STEMMER_FUNCTION_TYPE(): string {
 export function INVALID_TOKENIZER_FUNCTION(): string {
   return `tokenizer.tokenizerFn must be a function.`;
 }
+
+export function TYPE_ERROR_ID_MUST_BE_STRING(type: string): string {
+  return `"id" must be of type "string". Got "${type}" instead.`;
+}
+
+export function ID_ALREADY_EXISTS(id: string): string {
+  return `Document with ID "${id}" already exists.`;
+}

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -1,6 +1,5 @@
 import type { PropertiesSchema, Configuration, Lyra } from "../types";
 import type { Language } from "../tokenizer/languages";
-import type { Node } from "../radix-tree/node";
 import { defaultTokenizerConfig } from "../tokenizer";
 import { intersectTokenScores } from "../utils";
 import { assertSupportedLanguage } from "./common";

--- a/src/methods/remove.ts
+++ b/src/methods/remove.ts
@@ -1,6 +1,5 @@
 import type { ResolveSchema } from "../types";
 import type { PropertiesSchema, Lyra } from "../types";
-import type { Node } from "../radix-tree/node";
 import { removeDocumentByWord } from "../radix-tree/radix";
 import { defaultTokenizerConfig } from "../tokenizer";
 import * as ERRORS from "../errors";

--- a/src/methods/search.ts
+++ b/src/methods/search.ts
@@ -1,7 +1,6 @@
 import type { Lyra, PropertiesSchema } from "../types";
 import type { SearchProperties, ResolveSchema } from "../types";
 import type { Language } from "../tokenizer/languages";
-import type { Node } from "../radix-tree/node";
 import { defaultTokenizerConfig } from "../tokenizer";
 import { getIndices } from "./common";
 import { find as radixFind } from "../radix-tree/radix";

--- a/tap-snapshots/tests/insert.test.ts.test.cjs
+++ b/tap-snapshots/tests/insert.test.ts.test.cjs
@@ -1,0 +1,14 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`tests/insert.test.ts TAP insert should throw an error if the 'id' field is already taken > must match snapshot 1`] = `
+Error: Document with ID "john-01" already exists.
+`
+
+exports[`tests/insert.test.ts TAP insert should throw an error if the 'id' field is not a string > must match snapshot 1`] = `
+TypeError: "id" must be of type "string". Got "number" instead.
+`

--- a/tests/insert.test.ts
+++ b/tests/insert.test.ts
@@ -1,0 +1,107 @@
+import t from "tap";
+import { insert } from "../src/methods/insert";
+import { create } from "../src/methods/create";
+
+t.test("insert", async t => {
+  t.plan(4);
+
+  t.test("should use the 'id' field found in the document", async t => {
+    t.plan(2);
+
+    const db = await create({
+      schema: {
+        id: "string",
+        name: "string",
+      },
+    });
+
+    const i1 = await insert(db, {
+      id: "john-01",
+      name: "John",
+    });
+
+    const i2 = await insert(db, {
+      id: "doe-02",
+      name: "Doe",
+    });
+
+    t.equal(i1.id, "john-01");
+    t.equal(i2.id, "doe-02");
+  });
+
+  t.test("should use the custom 'id' function passed in the configuration object", async t => {
+    t.plan(2);
+
+    const db = await create({
+      schema: {
+        id: "string",
+        name: "string",
+      },
+    });
+
+    const i1 = await insert(
+      db,
+      {
+        id: "john-01",
+        name: "John",
+      },
+      {
+        id: doc => `${doc.name.toLowerCase()}-foo-bar-baz`,
+      },
+    );
+
+    const i2 = await insert(db, {
+      id: "doe-02",
+      name: "Doe",
+    });
+
+    t.equal(i1.id, "john-foo-bar-baz");
+    t.equal(i2.id, "doe-02");
+  });
+
+  t.test("should throw an error if the 'id' field is not a string", async t => {
+    t.plan(1);
+
+    const db = await create({
+      schema: {
+        id: "string",
+        name: "string",
+      },
+    });
+
+    try {
+      await insert(db, {
+        // @ts-expect-error error case
+        id: 123,
+        name: "John",
+      });
+    } catch (error) {
+      t.matchSnapshot(error);
+    }
+  });
+
+  t.test("should throw an error if the 'id' field is already taken", async t => {
+    t.plan(1);
+
+    const db = await create({
+      schema: {
+        id: "string",
+        name: "string",
+      },
+    });
+
+    await insert(db, {
+      id: "john-01",
+      name: "John",
+    });
+
+    try {
+      await insert(db, {
+        id: "john-01",
+        name: "John",
+      });
+    } catch (error) {
+      t.matchSnapshot(error);
+    }
+  });
+});

--- a/tests/lyra.edge.test.ts
+++ b/tests/lyra.edge.test.ts
@@ -1,5 +1,4 @@
 import t from "tap";
-import type { Node } from "../src/radix-tree/node";
 import { create, insert, save, load, search } from "../src/lyra";
 import { contains as trieContains } from "../src/radix-tree/radix";
 


### PR DESCRIPTION
Highly requested feature, will solve both #220 and #112.

By default, Lyra will check if a field `id` exists in the document we're trying to insert:

```js
insert(db, {
  id: 'foo-0123', // Will use this ID
  user: 'mitch'
})
```

if the `id` field does not exist, it will generate a random one.

We can also override the default `id` field by passing a function to the `insert` configuration:

```js
insert(db, {
  id: 'foo-0123',
  user: 'mitch'
}, {
  id: (doc /* the entire document */) => `${doc.user}.01`
})
```

in that case, the `id` will be `mitch.01`. The `id` configuration function can be either sync or async. 