### PR TITLE
perf(utils): prevent Object.hasOwn from not being defined

### DIFF
--- a/src/radix-tree/radix.ts
+++ b/src/radix-tree/radix.ts
@@ -131,7 +131,7 @@ function findAllWords(node: Node, output: FindResult, term: string, exact?: bool
 
     // always check in own property to prevent access to inherited properties
     // fix https://github.com/LyraSearch/lyra/issues/137
-    if (!Object.hasOwn(output, word)) {
+    if (!getOwnProperty(output, word)) {
       if (tolerance) {
         // computing the absolute difference of letters between the term and the word
         const difference = Math.abs(term.length - word.length);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,6 +60,11 @@ export function uniqueId(): string {
 }
 
 export function getOwnProperty<T = unknown>(object: Record<string, T>, property: string): T | undefined {
+  // Checks if `hasOwn` method is defined avoiding errors with older Node.js versions
+  if (Object.hasOwn === undefined) {
+    return Object.prototype.hasOwnProperty.call(object, property) ? object[property] : undefined;
+  }
+
   return Object.hasOwn(object, property) ? object[property] : undefined;
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,8 +1,8 @@
 import t from "tap";
-import { formatBytes, formatNanoseconds, intersectTokenScores } from "../src/utils";
+import { formatBytes, formatNanoseconds, getOwnProperty, intersectTokenScores } from "../src/utils";
 
 t.test("utils", t => {
-  t.plan(3);
+  t.plan(4);
 
   t.test("should correctly intersect 2 or more arrays", async t => {
     t.plan(1);
@@ -68,5 +68,16 @@ t.test("utils", t => {
     t.equal(formatNanoseconds(10_000_000_000n), "10s");
     t.equal(formatNanoseconds(100_000_000_000n), "100s");
     t.equal(formatNanoseconds(1000_000_000_000n), "1000s");
+  });
+
+  t.test("should check object properties", t => {
+    t.plan(2);
+
+    const myObject = {
+      foo: "bar",
+    };
+
+    t.equal(getOwnProperty(myObject, "foo"), "bar");
+    t.equal(getOwnProperty(myObject, "bar"), undefined);
   });
 });


### PR DESCRIPTION
## Context

This PR would replace the `Object.hasOwn` method by using a simple polyfill. This implementation makes Lyra compatible with **Node v14**.

It would be great for Lyra to be used in as many runtimes as possible.

## CI

If this PR would be merged it would be useful to add the tests on specific Node versions such as v14, v16, and v18.

## Tests

The tests were updated by adding the Unit Test to the `getOwnProperty` util method.
