### PR TITLE
feat(hooks): add afterRemove 

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,38 @@ const db = await create({
 await insertWithHooks(db, { author: "test", quote: "test" });
 ```
 
+### afterRemove hook
+
+The `afterRemove` hook is called after the deletion of a document on the
+database. The `hook` will be called with the `id` of the removed document.
+
+Example:
+
+
+```js
+import { create, insert, remove } from "@lyrasearch/lyra";
+
+async function hook1(id: string): Promise<void> {
+  // ...
+}
+
+const db = await create({
+  schema: {
+    author: "string",
+    quote: "string",
+  },
+  hooks: {
+    afterRemove: [hook1],
+  },
+});
+
+const { id } = await insert(db, { author: "test", quote: "test" });
+
+// ...
+
+await remove(db, id); // hook1 will be called
+```
+
 # License
 
 Lyra is licensed under the [Apache 2.0](/LICENSE.md) license.

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -17,6 +17,7 @@ import { intersectTokenScores } from "../algorithms.js";
  *   },
  *   hooks: {
  *     afterInsert: [afterInsertHook],
+ *     afterRemove: [afterRemoveHook],
  *   }
  * });
  */

--- a/src/methods/hooks.ts
+++ b/src/methods/hooks.ts
@@ -5,11 +5,16 @@ export interface AfterInsertHook {
   <S extends PropertiesSchema = PropertiesSchema>(this: Lyra<S>, id: string): Promise<void> | void;
 }
 
+export interface AfterRemoveHook {
+  <S extends PropertiesSchema = PropertiesSchema>(this: Lyra<S>, id: string): Promise<void> | void;
+}
+
 export type Hooks = {
   afterInsert?: AfterInsertHook | AfterInsertHook[];
+  afterRemove?: AfterRemoveHook | AfterRemoveHook[];
 };
 
-const SUPPORTED_HOOKS = ["afterInsert"];
+const SUPPORTED_HOOKS = ["afterInsert", "afterRemove"];
 
 export function validateHooks(hooks?: Hooks): void | never {
   if (hooks) {

--- a/src/methods/remove.ts
+++ b/src/methods/remove.ts
@@ -2,6 +2,7 @@ import { defaultTokenizerConfig } from "../tokenizer/index.js";
 import * as ERRORS from "../errors.js";
 import { removeDocumentByWord } from "../radix-tree/radix.js";
 import type { Lyra, PropertiesSchema, ResolveSchema } from "../types.js";
+import { hookRunner } from "./hooks.js";
 
 /**
  * Removes a document from a database.
@@ -54,6 +55,10 @@ export async function remove<S extends PropertiesSchema>(lyra: Lyra<S>, docID: s
 
   lyra.docs[docID] = undefined;
   lyra.docsCount--;
+
+  if (lyra.hooks.afterRemove) {
+    await hookRunner.call(lyra, lyra.hooks.afterRemove, docID);
+  }
 
   return true;
 }

--- a/tests/lyra.test.ts
+++ b/tests/lyra.test.ts
@@ -845,7 +845,8 @@ t.test("lyra", t => {
 });
 
 t.test("lyra - hooks", t => {
-  t.plan(2);
+  t.plan(3);
+
   t.test("should validate on lyra creation", async t => {
     t.plan(1);
 
@@ -888,6 +889,35 @@ t.test("lyra - hooks", t => {
       },
     });
     t.same(++callOrder, 2);
+  });
+
+  t.test("afterRemove hook", async t => {
+    let callOrder = 0;
+    const db = await create({
+      schema: {
+        quote: "string",
+        author: {
+          name: "string",
+          surname: "string",
+        },
+      },
+      hooks: {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        afterRemove: function (_id: string): void {
+          t.same(++callOrder, 1);
+        },
+      },
+    });
+
+    const { id } = await insert(db, {
+      quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
+        author: {
+          name: "Tom",
+          surname: "Riddle",
+        },
+      });
+
+    await remove(db, id);
   });
 });
 


### PR DESCRIPTION
## Context

This PR would introduce a new hook: **afterRemove**. The hook is very convenient at the time when you are working with cloned indexes and need to perform actions on the data.

This hook is called when a document is removed passing the `docID` as a reference:

> src/methods/remove.ts
```js
  lyra.docs[docID] = undefined;
  lyra.docsCount--;

  if (lyra.hooks.afterRemove) {
    await hookRunner.call(lyra, lyra.hooks.afterRemove, docID);
  }
```

I was undecided whether to return when the method is called: the ID of the deleted document or the entire Lyra instance, but the latter may present problems.

## Tests

The tests were updated by adding the Unit Test to the `afterRemove` hook.
