### PR TITLE
fix(types): fixes cjs types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,19 +7,22 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/cjs/index.cjs"
     },
     "./wasm": {
       "types": "./dist/wasm.d.ts",
       "import": "./dist/wasm.js"
     },
     "./internals": {
-      "types": "./dist/esm/internals/index.d.ts",
-      "import": "./dist/esm/internals/index.js"
+      "types": "./dist/internals.d.ts",
+      "import": "./dist/internals.js",
+      "require": "./dist/cjs/internals.cjs"
     },
     "./stemmer/*": {
       "types": "./dist/stemmer/*.d.ts",
-      "import": "./dist/stemmer/*.js"
+      "import": "./dist/stemmer/*.js",
+      "require": "./dist/cjs/stemmer/*.cjs"
     },
     "./cjs": {
       "types": "./dist/cjs/index.d.cts",

--- a/src/methods/common.ts
+++ b/src/methods/common.ts
@@ -1,6 +1,6 @@
 import * as ERRORS from "../errors.js";
-import type { Lyra, PropertiesSchema, ResolveSchema } from "../types";
-import type { SearchParams } from "./search";
+import type { Lyra, PropertiesSchema, ResolveSchema } from "../types.js";
+import type { SearchParams } from "./search.js";
 
 export function assertDocSchema<S extends PropertiesSchema>(doc: ResolveSchema<S>, lyraSchema: PropertiesSchema) {
   if (!recursiveCheckDocSchema(doc, lyraSchema)) {

--- a/src/radix-tree/node.ts
+++ b/src/radix-tree/node.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from "../types";
+import type { Nullable } from "../types.js";
 import { uniqueId } from "../utils.js";
 
 export interface Node {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "baseUrl": ".",
     "paths": {
       "@stemmer/*": ["./stemmer/lib/*"]


### PR DESCRIPTION
This PR fixes types when using TypeScript via CommonJS modules. It introduces a breaking change in TypeScript, as follows:

```diff
- import { create, insert, search } from '@lyrasearch/lyra';
- import { stemmer } from '@lyrasearch/lyra/stemmer/it';
- import { requireLyraInternals } from '@lyrasearch/lyra/internals';

+ import { create, insert, search } from '@lyrasearch/lyra/cjs';
+ import { stemmer } from '@lyrasearch/lyra/cjs/stemmer/it';
+ import { requireLyraInternals } from '@lyrasearch/lyra/cjs/internals';
``` 

We basically have to manually tell TypeScript to get types and functions from CommonJS files.

Fixes #243