### PR TITLE
feat(search): adds fields boosting interface

### DIFF
--- a/src/algorithms.ts
+++ b/src/algorithms.ts
@@ -1,4 +1,5 @@
 import type { BM25Params, TokenScore } from "./types.js";
+import * as ERRORS from "./errors.js";
 
 // Adapted from https://github.com/lovasoa/fast_array_intersect
 // MIT Licensed (https://github.com/lovasoa/fast_array_intersect/blob/master/LICENSE)
@@ -52,6 +53,10 @@ export function intersectTokenScores(arrays: TokenScore[][]): TokenScore[] {
 }
 
 export function prioritizeTokenScores(arrays: TokenScore[][], boost: number): TokenScore[] {
+  if (boost === 0) {
+    throw new Error(ERRORS.INVALID_BOOST_VALUE());
+  }
+
   const tokenMap: Record<string, number> = {};
 
   const mapsLength = arrays.length;
@@ -61,10 +66,10 @@ export function prioritizeTokenScores(arrays: TokenScore[][], boost: number): To
     const entriesLength = arr.length;
     for (let j = 0; j < entriesLength; j++) {
       const [token, score] = arr[j];
-      const boostScore = score + boost;
+      const boostScore = score * boost;
 
       if (token in tokenMap) {
-        tokenMap[token] += 0.5 + boostScore;
+        tokenMap[token] *= 1.5 + boostScore;
       } else {
         tokenMap[token] = boostScore;
       }

--- a/src/algorithms.ts
+++ b/src/algorithms.ts
@@ -1,5 +1,4 @@
-import type { BM25Params } from "./types.js";
-import { TokenScore } from "./types.js";
+import type { BM25Params, TokenScore } from "./types.js";
 
 // Adapted from https://github.com/lovasoa/fast_array_intersect
 // MIT Licensed (https://github.com/lovasoa/fast_array_intersect/blob/master/LICENSE)
@@ -52,7 +51,7 @@ export function intersectTokenScores(arrays: TokenScore[][]): TokenScore[] {
   return result;
 }
 
-export function prioritizeTokenScores(arrays: TokenScore[][]): TokenScore[] {
+export function prioritizeTokenScores(arrays: TokenScore[][], boost: number): TokenScore[] {
   const tokenMap: Record<string, number> = {};
 
   const mapsLength = arrays.length;
@@ -62,11 +61,12 @@ export function prioritizeTokenScores(arrays: TokenScore[][]): TokenScore[] {
     const entriesLength = arr.length;
     for (let j = 0; j < entriesLength; j++) {
       const [token, score] = arr[j];
+      const boostScore = score + boost;
 
       if (token in tokenMap) {
-        tokenMap[token] += score + 0.5
+        tokenMap[token] += 0.5 + boostScore;
       } else {
-        tokenMap[token] = score;
+        tokenMap[token] = boostScore;
       }
     }
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -75,3 +75,7 @@ export function INVALID_STEMMER_FUNCTION_TYPE(): string {
 export function INVALID_TOKENIZER_FUNCTION(): string {
   return `tokenizer.tokenizerFn must be a function.`;
 }
+
+export function INVALID_BOOST_VALUE(): string {
+  return `Boost value must be a number greater than, or less than 0.`;
+}

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -40,7 +40,6 @@ export async function create<S extends PropertiesSchema>(properties: Configurati
     tokenOccurrencies: {},
     avgFieldLength: {},
     fieldLengths: {},
-    boost: properties.boost ?? {},
     components: {
       tokenizer,
       algorithms: {

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -1,7 +1,7 @@
+import type { Configuration, Lyra, PropertiesSchema } from "../types.js";
 import { defaultTokenizerConfig, Language } from "../tokenizer/index.js";
 import * as ERRORS from "../errors.js";
 import { create as createNode } from "../radix-tree/node.js";
-import type { Configuration, Lyra, PropertiesSchema } from "../types.js";
 import { validateHooks } from "./hooks.js";
 import { intersectTokenScores } from "../algorithms.js";
 
@@ -40,6 +40,7 @@ export async function create<S extends PropertiesSchema>(properties: Configurati
     tokenOccurrencies: {},
     avgFieldLength: {},
     fieldLengths: {},
+    boost: properties.boost ?? {},
     components: {
       tokenizer,
       algorithms: {

--- a/src/methods/search.ts
+++ b/src/methods/search.ts
@@ -203,7 +203,7 @@ export async function search<S extends PropertiesSchema>(
 
     const docIds = indexMap[index];
     const vals = Object.values(docIds);
-    docsIntersection[index] = prioritizeTokenScores(vals);
+    docsIntersection[index] = prioritizeTokenScores(vals, lyra.boost[index] ?? 0);
     const uniqueDocs = docsIntersection[index];
 
     const uniqueDocsLength = uniqueDocs.length;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export type AlgorithmsConfig = {
   intersectTokenScores: IIntersectTokenScores;
 };
 
+export type PropertiesBoost<S extends PropertiesSchema> = {
+  [P in keyof S]?: number;
+};
+
 export type Configuration<S extends PropertiesSchema> = {
   /**
    * The structure of the document to be inserted into the database.
@@ -42,6 +46,7 @@ export type Configuration<S extends PropertiesSchema> = {
   edge?: boolean;
   hooks?: Hooks;
   components?: Components;
+  boost?: PropertiesBoost<S>;
 };
 
 export type Data<S extends PropertiesSchema> = {
@@ -69,6 +74,7 @@ export interface Lyra<S extends PropertiesSchema> extends Data<S> {
   frequencies: FrequencyMap;
   docsCount: number;
   avgFieldLength: Record<string, number>;
+  boost: PropertiesBoost<S>;
   fieldLengths: Record<string, Record<string, number>>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,6 @@ export type Configuration<S extends PropertiesSchema> = {
   edge?: boolean;
   hooks?: Hooks;
   components?: Components;
-  boost?: PropertiesBoost<S>;
 };
 
 export type Data<S extends PropertiesSchema> = {
@@ -74,7 +73,6 @@ export interface Lyra<S extends PropertiesSchema> extends Data<S> {
   frequencies: FrequencyMap;
   docsCount: number;
   avgFieldLength: Record<string, number>;
-  boost: PropertiesBoost<S>;
   fieldLengths: Record<string, Record<string, number>>;
 }
 

--- a/tests/boosting.test.ts
+++ b/tests/boosting.test.ts
@@ -1,0 +1,69 @@
+import t from "tap"
+import { create, insert, search } from "../src/index.js";
+
+t.test("boosting", t => {
+  t.plan(1);
+
+  t.test("field boosting", async t => {
+    t.plan(1);
+
+    const db1 = await create({
+      schema: {
+        id: "string",
+        title: "string",
+        description: "string"
+      }
+    });
+
+    await insert(db1, {
+      id: "1",
+      title: "Powerful computer with 16GB RAM",
+      description: "A powerful computer with 16GB RAM and a 1TB SSD, perfect for gaming and video editing."
+    });
+
+    await insert(db1, {
+      id: "2",
+      title: "PC with 8GB RAM. Good for gaming and browsing the web.",
+      description: "A personal computer with 8GB RAM and a 500GB SSD, perfect for browsing the web and watching movies. This computer is also great for kids."
+    });
+
+    const { hits } = await search(db1, {
+      term: "computer for gaming, browsing, and movies",
+    });
+
+
+    const db2 = await create({
+      schema: {
+        id: "string",
+        title: "string",
+        description: "string"
+      },
+      boost: {
+        title: 0.5
+      }
+    });
+
+    await insert(db2, {
+      id: "1",
+      title: "Powerful computer with 16GB RAM",
+      description: "A powerful computer with 16GB RAM and a 1TB SSD, perfect for gaming and video editing."
+    });
+
+    await insert(db2, {
+      id: "2",
+      title: "PC with 8GB RAM. Good for gaming and browsing the web.",
+      description: "A personal computer with 8GB RAM and a 500GB SSD, perfect for browsing the web and watching movies. This computer is also great for kids."
+    });
+
+    const { hits: hits2 } = await search(db2, {
+      term: "computer for gaming, browsing, and movies",
+    });
+
+    console.log({
+      hits,
+      hits2
+    })
+
+    t.equal(hits[0].score < hits2[0].score, true);
+  });
+});

--- a/tests/boosting.test.ts
+++ b/tests/boosting.test.ts
@@ -5,9 +5,9 @@ t.test("boosting", t => {
   t.plan(1);
 
   t.test("field boosting", async t => {
-    t.plan(1);
+    t.plan(2);
 
-    const db1 = await create({
+    const db = await create({
       schema: {
         id: "string",
         title: "string",
@@ -15,55 +15,40 @@ t.test("boosting", t => {
       }
     });
 
-    await insert(db1, {
+    await insert(db, {
       id: "1",
       title: "Powerful computer with 16GB RAM",
       description: "A powerful computer with 16GB RAM and a 1TB SSD, perfect for gaming and video editing."
     });
 
-    await insert(db1, {
+    await insert(db, {
       id: "2",
       title: "PC with 8GB RAM. Good for gaming and browsing the web.",
       description: "A personal computer with 8GB RAM and a 500GB SSD, perfect for browsing the web and watching movies. This computer is also great for kids."
     });
 
-    const { hits } = await search(db1, {
-      term: "computer for gaming, browsing, and movies",
+    const { hits: hits1 } = await search(db, {
+      term: "computer for browsing and movies",
     });
 
-
-    const db2 = await create({
-      schema: {
-        id: "string",
-        title: "string",
-        description: "string"
-      },
+    const { hits: hits2 } = await search(db, {
+      term: "computer for browsing and movies",
       boost: {
-        title: 0.5
+        title: 2.5
       }
     });
 
-    await insert(db2, {
-      id: "1",
-      title: "Powerful computer with 16GB RAM",
-      description: "A powerful computer with 16GB RAM and a 1TB SSD, perfect for gaming and video editing."
-    });
+    try {
+      await search(db, {
+        term: "computer for browsing and movies",
+        boost: {
+          title: 0
+        }
+      });
+    } catch (err) {
+      t.same(err.message, `Boost value must be a number greater than, or less than 0.`);
+    }
 
-    await insert(db2, {
-      id: "2",
-      title: "PC with 8GB RAM. Good for gaming and browsing the web.",
-      description: "A personal computer with 8GB RAM and a 500GB SSD, perfect for browsing the web and watching movies. This computer is also great for kids."
-    });
-
-    const { hits: hits2 } = await search(db2, {
-      term: "computer for gaming, browsing, and movies",
-    });
-
-    console.log({
-      hits,
-      hits2
-    })
-
-    t.equal(hits[0].score < hits2[0].score, true);
+    t.equal(hits1[0].score < hits2[0].score, true);
   });
 });


### PR DESCRIPTION
This PR introduces a field-boosting API, which allows you to boost research when a given search term string appears in one of the desired fields. Example:

```js
import { create, insert, search } from "@lyrasearch/lyra";

const db = await create({
  schema: {
    author: "string",
    quote: "string",
    meta: {
      tags: "string",
    }
  }
})

// insert stuff...
await insert(...)
await insert(...)
await insert(...)

await search({
  term: "John Doe",
  boost: {
    author: 1.5,
    "meta.tags": 1.1
  }
})
```

The configuration above will boost `author` and `meta.tags` respectively by `1.5` and `1.1`.

Still a work in progress, will switch to percentage-based boosting before merging.