### PR TITLE
Feat: adds facets to search

### DIFF
--- a/src/facets.ts
+++ b/src/facets.ts
@@ -1,4 +1,5 @@
 import type { FacetSorting, FacetsSearch, PropertiesSchema, ResolveSchema, TokenScore } from "./types.d.ts";
+import { getNested } from './utils.js';
 
 export type FacetReturningValue = {
   [key: string]: {
@@ -9,24 +10,46 @@ export type FacetReturningValue = {
   }
 }
 
-export function getFacets<S extends PropertiesSchema>(docs: Record<string, ResolveSchema<S> | undefined>, results: TokenScore[], facetsConfig: FacetsSearch<S>): FacetReturningValue {
+export function getFacets<S extends PropertiesSchema>(schema: PropertiesSchema, docs: Record<string, ResolveSchema<S> | undefined>, results: TokenScore[], facetsConfig: FacetsSearch<S>): FacetReturningValue {
   const facets: FacetReturningValue = {};
   const allIDs = results.map(([id]) => id);
   const allDocs = allIDs.map((id) => docs[id]);
   const facetKeys = Object.keys(facetsConfig);
 
   for (const facet of facetKeys) {
+    const facetType = getFacetType(schema, facet);
+    let values = {};
+
+    if (facetType === "boolean") {
+      values = {
+        true: 0,
+        false: 0,
+      }
+    
+    // Hack to guarantee the same order of ranges as specified by the user
+    } else if (facetType === "number") {
+      const { ranges } = (facetsConfig as any)[facet];
+      const tmp = [];
+      for (const range of ranges) {
+        tmp.push([`${range.from}-${range.to}`, 0]);
+      }
+      values = Object.fromEntries(tmp as any);
+    }
+
     facets[facet] = {
       count: 0,
-      values: {},
+      values,
     };
   }
 
   const allDocsLength = allDocs.length;
   for (let i = 0; i < allDocsLength; i++) {
     const doc = allDocs[i];
+
     for (const facet of facetKeys) {
-      const facetValue = doc![facet];
+      const facetValue = facet.includes('.')
+        ? getNested<string>(doc!, facet)!
+        : doc![facet] as number | boolean;
 
       // String based facets
       if (typeof facetValue === "string") {
@@ -61,21 +84,40 @@ export function getFacets<S extends PropertiesSchema>(docs: Record<string, Resol
   }
 
   for (const facet of facetKeys) {
+    const facetType = getFacetType(schema, facet);
+
+    // Count the number of values for each facet
     facets[facet].count = Object.keys(facets[facet].values).length;
-    facets[facet].values = Object.fromEntries(
-      Object.entries(facets[facet].values)
-        .sort((a, b) => sortingPredicate((facetsConfig as any)[facet].sort, a, b))
-        .slice((facetsConfig as any)[facet].offset ?? 0, (facetsConfig as any)[facet].limit ?? 10),
-    )
+
+    // Sort only string-based facets
+    if (facetType === "string") {
+      facets[facet].values = Object.fromEntries(
+        Object.entries(facets[facet].values)
+          .sort((a, b) => sortingPredicate((facetsConfig as any)[facet].sort, a, b))
+          .slice((facetsConfig as any)[facet].offset ?? 0, (facetsConfig as any)[facet].limit ?? 10),
+      )
+    }
   }
 
   return facets;
 }
 
-function sortingPredicate(order: FacetSorting = "asc", a: [string, number], b: [string, number]) {
+const facetTypeCache = new Map<string, string>();
+
+function getFacetType(schema: PropertiesSchema, facet: string) {
+  if (facetTypeCache.has(facet)) {
+    return facetTypeCache.get(facet)!;
+  }
+
+  const facetType = getNested<string>(schema, facet)!;
+  facetTypeCache.set(facet, facetType);
+  return facetType;
+}
+
+function sortingPredicate(order: FacetSorting = "desc", a: [string, number], b: [string, number]) {
   if (order.toLowerCase() === "asc") {
-    return b[1] - a[1];
-  } else {
     return a[1] - b[1];
+  } else {
+    return b[1] - a[1];
   }
 }

--- a/src/facets.ts
+++ b/src/facets.ts
@@ -9,7 +9,8 @@ export type FacetReturningValue = {
   }
 }
 
-export async function populateFacets<S extends PropertiesSchema>(docs: Record<string, ResolveSchema<S> | undefined>, facets: FacetReturningValue, results: TokenScore[], facetsConfig: FacetsSearch<S>): Promise<FacetReturningValue> {
+export function getFacets<S extends PropertiesSchema>(docs: Record<string, ResolveSchema<S> | undefined>, results: TokenScore[], facetsConfig: FacetsSearch<S>): FacetReturningValue {
+  const facets: FacetReturningValue = {};
   const allIDs = results.map(([id]) => id);
   const allDocs = allIDs.map((id) => docs[id]);
   const facetKeys = Object.keys(facetsConfig);
@@ -64,7 +65,7 @@ export async function populateFacets<S extends PropertiesSchema>(docs: Record<st
     facets[facet].values = Object.fromEntries(
       Object.entries(facets[facet].values)
         .sort((a, b) => sortingPredicate((facetsConfig as any)[facet].sort, a, b))
-        .slice(0, (facetsConfig as any)[facet].size ?? 10),
+        .slice((facetsConfig as any)[facet].offset ?? 0, (facetsConfig as any)[facet].limit ?? 10),
     )
   }
 

--- a/src/facets.ts
+++ b/src/facets.ts
@@ -1,4 +1,4 @@
-import type { FacetSorting, FacetsSearch, PropertiesSchema, ResolveSchema, TokenScore } from "./types.d.ts";
+import type { FacetSorting, FacetsSearch, PropertiesSchema, ResolveSchema, TokenScore } from "./types.js";
 import { getNested } from './utils.js';
 
 export type FacetReturningValue = {
@@ -20,14 +20,8 @@ export function getFacets<S extends PropertiesSchema>(schema: PropertiesSchema, 
     const facetType = getFacetType(schema, facet);
     let values = {};
 
-    if (facetType === "boolean") {
-      values = {
-        true: 0,
-        false: 0,
-      }
-    
     // Hack to guarantee the same order of ranges as specified by the user
-    } else if (facetType === "number") {
+    if (facetType === "number") {
       const { ranges } = (facetsConfig as any)[facet];
       const tmp = [];
       for (const range of ranges) {

--- a/src/facets.ts
+++ b/src/facets.ts
@@ -1,0 +1,58 @@
+import type { FacetSorting, FacetsSearch, PropertiesSchema, ResolveSchema, TokenScore } from "./types.d.ts";
+
+export type FacetReturningValue = {
+  [key: string]: {
+    count: number;
+    values: {
+      [key: string]: number;
+    }
+  }
+}
+
+export async function populateFacets<S extends PropertiesSchema>(docs: Record<string, ResolveSchema<S> | undefined>, facets: FacetReturningValue, results: TokenScore[], facetsConfig: FacetsSearch<S>): Promise<FacetReturningValue> {
+  const allIDs = results.map(([id]) => id);
+  const allDocs = allIDs.map((id) => docs[id]);
+  const facetKeys = Object.keys(facetsConfig);
+
+  for (const facet of facetKeys) {
+    facets[facet] = {
+      count: 0,
+      values: {},
+    };
+  }
+
+  const allDocsLength = allDocs.length;
+  for (let i = 0; i < allDocsLength; i++) {
+    const doc = allDocs[i];
+    for (const facet of facetKeys) {
+      const facetValue = doc![facet];
+      if (typeof facetValue === "string") {
+        if (facets[facet].values[facetValue] === undefined) {
+          facets[facet].values[facetValue] = 1;
+        } else {
+          facets[facet].values[facetValue]++;
+        }
+      }
+    }
+  }
+
+
+  for (const facet of facetKeys) {
+    facets[facet].count = Object.keys(facets[facet].values).length;
+    facets[facet].values = Object.fromEntries(
+      Object.entries(facets[facet].values)
+        .sort((a, b) => sortingPredicate((facetsConfig as any)[facet].sort, a, b))
+        .slice(0, (facetsConfig as any)[facet].size ?? 10),
+    )
+  }
+
+  return facets;
+}
+
+function sortingPredicate(order: FacetSorting = "ASC", a: [string, number], b: [string, number]) {
+  if (order.toLowerCase() === "asc") {
+    return b[1] - a[1];
+  } else {
+    return a[1] - b[1];
+  }
+}

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -40,7 +40,6 @@ export async function create<S extends PropertiesSchema>(properties: Configurati
     tokenOccurrencies: {},
     avgFieldLength: {},
     fieldLengths: {},
-    facets: properties.facets ?? [],
     components: {
       tokenizer,
       algorithms: {

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -40,6 +40,7 @@ export async function create<S extends PropertiesSchema>(properties: Configurati
     tokenOccurrencies: {},
     avgFieldLength: {},
     fieldLengths: {},
+    facets: properties.facets ?? [],
     components: {
       tokenizer,
       algorithms: {

--- a/src/methods/search.ts
+++ b/src/methods/search.ts
@@ -217,6 +217,11 @@ export async function search<S extends PropertiesSchema>(
     const tokensLength = tokens.length;
     for (let j = 0; j < tokensLength; j++) {
       const term = tokens[j];
+
+      // Here we get a TypeScript error: Type instantiation is excessively deep and possibly infinite.
+      // Type definition is correct, but TypeScript is not able to infer the type recursively.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       const documentIDs = getDocumentIDsFromSearch(lyra, { ...params, index, term, exact });
 
       // lyraOccurrencies[term] can be undefined, 0, string, or { [k: string]: number }

--- a/src/methods/search.ts
+++ b/src/methods/search.ts
@@ -268,7 +268,7 @@ export async function search<S extends PropertiesSchema>(
   const uniqueDocsArray = Object.entries(uniqueDocsIDs).sort(sortTokenScorePredicate);
   const resultIDs: Set<string> = new Set();
   // Populate facets if needed
-  const facets = shouldCalculateFacets ? getFacets(lyra.docs, uniqueDocsArray, params.facets!) : {};
+  const facets = shouldCalculateFacets ? getFacets(lyra.schema, lyra.docs, uniqueDocsArray, params.facets!) : {};
 
   // We already have the list of ALL the document IDs containing the search terms.
   // We loop over them starting from a positional value "offset" and ending at "offset + limit"

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,12 +38,23 @@ type FacetTypeInterfaces = {
   };
 }
 
+export type NestedValue<
+  S extends PropertiesSchema,
+  T extends SearchProperties<S> = SearchProperties<S>,
+> = T extends keyof S
+  ? S[T] extends PropertyType
+    ? S[T]
+    : never
+  : T extends `${infer K}.${string}`
+  ? K extends keyof S
+    ? S[K] extends PropertiesSchema
+      ? NestedValue<S[K]>
+      : never
+    : never
+  : never;
+
 export type FacetsSearch<S extends PropertiesSchema> = {
-  // This is giving the following error:
-  // Type 'S[P]' cannot be used to index type 'FacetTypeInterfaces'.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore ignoring just for committing.
-  [P in FacetsConfig<S>[number]]?: FacetTypeInterfaces[S[P]];
+  [P in FacetsConfig<S>[number]]?: FacetTypeInterfaces[NestedValue<S>];
 };
 
 export type FacetsConfig<S extends PropertiesSchema> = SearchProperties<S>[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,24 +37,13 @@ type FacetTypeInterfaces = {
   };
 }
 
-export type NestedValue<
-  S extends PropertiesSchema,
-  T extends SearchProperties<S> = SearchProperties<S>,
-> = T extends keyof S
-  ? S[T] extends PropertyType
-    ? S[T]
-    : never
-  : T extends `${infer K}.${string}`
-  ? K extends keyof S
-    ? S[K] extends PropertiesSchema
-      ? NestedValue<S[K]>
+export type FacetsSearch<S extends PropertiesSchema, P extends string = "", K extends keyof S = keyof S> = K extends string
+  ? S[K] extends PropertiesSchema
+    ? FacetsSearch<S[K], `${P}${K}.`>
+    : S[K] extends PropertyType
+      ? { [key in `${P}${K}`]?: FacetTypeInterfaces[S[K]] }
       : never
-    : never
   : never;
-
-export type FacetsSearch<S extends PropertiesSchema> = {
-  [P in SearchProperties<S>[number]]?: FacetTypeInterfaces[NestedValue<S>];
-};
 
 export type PropertyType = "string" | "number" | "boolean";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,6 @@ type FacetTypeInterfaces = {
   };
   number: {
     ranges: {from: number, to: number}[]
-    sort?: FacetSorting;
   };
   boolean: {
     true?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,8 @@ export type ValuesOf<T extends any[]>= T[number];
 
 export type FacetsSearch<S extends PropertiesSchema> = {
   [K in FacetsConfig<S>[number]]?: {
-    size?: number;
+    limit?: number;
+    offset?: number;
     sort?: FacetSorting;
     ranges?: {from: number, to: number}[]
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export type PropertiesBoost<S extends PropertiesSchema> = {
   [P in keyof S]?: number;
 };
 
+export type FacetsConfig<S extends PropertiesSchema> = SearchProperties<S>[];
+
 export type Configuration<S extends PropertiesSchema> = {
   /**
    * The structure of the document to be inserted into the database.
@@ -46,6 +48,7 @@ export type Configuration<S extends PropertiesSchema> = {
   edge?: boolean;
   hooks?: Hooks;
   components?: Components;
+  facets?: FacetsConfig<S>;
 };
 
 export type Data<S extends PropertiesSchema> = {
@@ -69,6 +72,7 @@ export interface Lyra<S extends PropertiesSchema> extends Data<S> {
   schema: S;
   edge: boolean;
   hooks: Hooks;
+  facets: FacetsConfig<S>;
   components?: Components;
   frequencies: FrequencyMap;
   docsCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,10 +53,8 @@ export type NestedValue<
   : never;
 
 export type FacetsSearch<S extends PropertiesSchema> = {
-  [P in FacetsConfig<S>[number]]?: FacetTypeInterfaces[NestedValue<S>];
+  [P in SearchProperties<S>[number]]?: FacetTypeInterfaces[NestedValue<S>];
 };
-
-export type FacetsConfig<S extends PropertiesSchema> = SearchProperties<S>[];
 
 export type PropertyType = "string" | "number" | "boolean";
 
@@ -84,7 +82,6 @@ export type Configuration<S extends PropertiesSchema> = {
   edge?: boolean;
   hooks?: Hooks;
   components?: Components;
-  facets?: FacetsConfig<S>;
 };
 
 export type Data<S extends PropertiesSchema> = {
@@ -108,7 +105,6 @@ export interface Lyra<S extends PropertiesSchema> extends Data<S> {
   schema: S;
   edge: boolean;
   hooks: Hooks;
-  facets: FacetsConfig<S>;
   components?: Components;
   frequencies: FrequencyMap;
   docsCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,10 +24,12 @@ export type FacetSorting = "asc" | "desc" | "ASC" | "DESC";
 
 export type ValuesOf<T extends any[]>= T[number];
 
+
 export type FacetsSearch<S extends PropertiesSchema> = {
   [K in FacetsConfig<S>[number]]?: {
     size?: number;
     sort?: FacetSorting;
+    ranges?: {from: number, to: number}[]
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,17 +22,31 @@ export type SearchProperties<
 
 export type FacetSorting = "asc" | "desc" | "ASC" | "DESC";
 
-export type ValuesOf<T extends any[]>= T[number];
-
-
-export type FacetsSearch<S extends PropertiesSchema> = {
-  [K in FacetsConfig<S>[number]]?: {
+type FacetTypeInterfaces = {
+  string: {
     limit?: number;
     offset?: number;
     sort?: FacetSorting;
-    ranges?: {from: number, to: number}[]
-  }
+  };
+  number: {
+    ranges: {from: number, to: number}[]
+    sort?: FacetSorting;
+  };
+  boolean: {
+    true?: boolean;
+    false?: boolean;
+  };
 }
+
+export type FacetsSearch<S extends PropertiesSchema> = {
+  // This is giving the following error:
+  // Type 'S[P]' cannot be used to index type 'FacetTypeInterfaces'.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore ignoring just for committing.
+  [P in FacetsConfig<S>[number]]?: FacetTypeInterfaces[S[P]];
+};
+
+export type FacetsConfig<S extends PropertiesSchema> = SearchProperties<S>[];
 
 export type PropertyType = "string" | "number" | "boolean";
 
@@ -47,8 +61,6 @@ export type AlgorithmsConfig = {
 export type PropertiesBoost<S extends PropertiesSchema> = {
   [P in keyof S]?: number;
 };
-
-export type FacetsConfig<S extends PropertiesSchema> = SearchProperties<S>[];
 
 export type Configuration<S extends PropertiesSchema> = {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,17 @@ export type SearchProperties<
     : TKey
   : never;
 
+export type FacetSorting = "asc" | "desc" | "ASC" | "DESC";
+
+export type ValuesOf<T extends any[]>= T[number];
+
+export type FacetsSearch<S extends PropertiesSchema> = {
+  [K in FacetsConfig<S>[number]]?: {
+    size?: number;
+    sort?: FacetSorting;
+  }
+}
+
 export type PropertyType = "string" | "number" | "boolean";
 
 export type PropertiesSchema = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,3 +100,10 @@ export function insertSortedValue(
 export function sortTokenScorePredicate(a: TokenScore, b: TokenScore): number {
   return b[1] - a[1];
 }
+
+export function getNested<T = unknown>(
+  obj: Record<string, unknown>,
+  path: string
+): T | undefined {
+  return new Function('_', 'return _.' + path)(obj);
+}

--- a/tests/facets.test.ts
+++ b/tests/facets.test.ts
@@ -15,12 +15,7 @@ t.test("facets", (t) => {
           tag: "string",
           isFavorite: "boolean",
         }
-      },
-      facets: [
-        "author",
-        "meta.tag",
-        "meta.isFavorite"
-      ]
+      }
     });
 
     await insert(db, {
@@ -104,11 +99,7 @@ t.test("facets", (t) => {
         name: "string",
         price: "number",
         category: "string"
-      },
-      facets: [
-        "price",
-        "name"
-      ]
+      }
     });
 
     await insert(db, {

--- a/tests/facets.test.ts
+++ b/tests/facets.test.ts
@@ -1,0 +1,172 @@
+import t from "tap";
+import { create, insert, search } from "../src/index.js";
+
+t.test("facets", (t) => {
+  t.plan(2);
+
+  t.test("should generate correct facets", async t => {
+    t.plan(6);
+
+    const db = await create({
+      schema: {
+        author: "string",
+        quote: "string",
+        meta: {
+          tag: "string",
+          isFavorite: "boolean",
+        }
+      },
+      facets: [
+        "author",
+        "meta.tag",
+        "meta.isFavorite"
+      ]
+    });
+
+    await insert(db, {
+      author: "Mahatma Gandhi",
+      quote: "Be the change you wish to see in the world",
+      meta: {
+        tag: "inspirational",
+        isFavorite: true
+      }
+    });
+
+    await insert(db, {
+      author: "Thomas A. Edison",
+      quote: "I have not failed. I've just found 10,000 ways that won't work.",
+      meta: {
+        tag: "inspirational",
+        isFavorite: true
+      }
+    });
+
+    await insert(db, {
+      author: "Confucius",
+      quote: "It does not matter how slowly you go as long as you do not stop.",
+      meta: {
+        tag: "inspirational",
+        isFavorite: false
+      }
+    });
+
+    await insert(db, {
+      author: "Helen Keller",
+      quote: "The best and most beautiful things in the world cannot be seen or even touched - they must be felt with the heart.",
+      meta: {
+        tag: "love",
+        isFavorite: true
+      }
+    });
+
+    await insert(db, {
+      author: "Steve Jobs",
+      quote: "Your time is limited, so don't waste it living someone else's life.",
+      meta: {
+        tag: "inspirational",
+        isFavorite: false
+      }
+    });
+
+    await insert(db, {
+      author: "Steve Jobs",
+      quote: "The only way to do great work is to love what you do.",
+      meta: {
+        tag: "inspirational",
+        isFavorite: false
+      }
+    });
+
+    const results = await search(db, {
+      term: "work time",
+      facets: {
+        "meta.isFavorite": {
+          true: true,
+          false: false,
+        },
+        "meta.tag": {},
+        "author": {}
+      }});
+
+      t.same(results.facets?.['meta.isFavorite'].count, 2)
+      t.same(results.facets?.['meta.isFavorite'].values, { true: 1, false: 2 });
+      t.same(results.facets?.['meta.tag'].count, 1);
+      t.same(results.facets?.['meta.tag'].values, { inspirational: 3 });
+      t.same(results.facets?.author.count, 2);
+      t.same(results.facets?.author.values, { "Steve Jobs": 2, "Thomas A. Edison": 1 });
+  });
+
+  t.test("should correctly handle range facets", async t => {
+    t.plan(5);
+
+    const db = await create({
+      schema: {
+        name: "string",
+        price: "number",
+        category: "string"
+      },
+      facets: [
+        "price",
+        "name"
+      ]
+    });
+
+    await insert(db, {
+      name: "Chocolate",
+      price: 1.99,
+      category: "groceries"
+    })
+
+    await insert(db, {
+      name: "Milk",
+      price: 2.99,
+      category: "groceries"
+    })
+
+    await insert(db, {
+      name: "Bread",
+      price: 3.99,
+      category: "groceries"
+    })
+
+    await insert(db, {
+      name: "Eggs",
+      price: 4.99,
+      category: "groceries"
+    })
+
+    await insert(db, {
+      name: "Cheese",
+      price: 5.99,
+      category: "groceries"
+    })
+
+    await insert(db, {
+      name: "Butter",
+      price: 6.99,
+      category: "groceries"
+    })
+
+    const results = await search(db, {
+      term: "groceries",
+      properties: ['category'],
+      facets: {
+        price: {
+          ranges: [
+            { from: 0, to: 2 },
+            { from: 2, to: 4 },
+            { from: 4, to: 6 },
+            { from: 6, to: 8 },
+          ]
+        }
+      }
+    });
+
+    t.same(results.facets?.price.count, 4);
+    t.same(results.facets?.price.values['0-2'], 1);
+    t.same(results.facets?.price.values['2-4'], 2);
+    t.same(results.facets?.price.values['4-6'], 2);
+    t.same(results.facets?.price.values['6-8'], 1);
+
+  });
+});


### PR DESCRIPTION
This PR aims to add support for facets while searching with Lyra.
The API is pretty straightforward and will likely close https://github.com/LyraSearch/lyra/issues/206, and pave the ground for https://github.com/LyraSearch/lyra/issues/212.

### Example API

Given the following database, we'll now need to select which fields will be available while performing a facet query:
```js
const db = await create({
  schema: {
    id: "string",
    brand: "string",
    model: "string",
    year: "number",
    price: "number",
    used: "boolean",
    available: "boolean",
  }
});
```

Now let's insert some data. I'm experimenting with a format similar to the following one:

```jsonl
{"id":"3e4e0dc3-7cb9-4a03-9a36-2c66f51e08c9","brand":"Acura","year":2000,"model":"TL","available":true,"used":false,"price":36899},
{"id":"321b5c59-be55-48b9-a3d4-3e1586d1a863","brand":"Dodge","year":2009,"model":"Journey","available":false,"used":true,"price":12799},
{"id":"62123f1e-9f13-474a-a282-8d141c296edf","brand":"Nissan","year":1998,"model":"Frontier","available":true,"used":false,"price":48840},
```

So let's batch insert using the `batchInsert` built-in function:

```js
await insertBatch(db, data);
```

Now we need to perform search. Lyra currently supports 3 data types: `string`, `boolean`, `number`, and we will be able to perform facet queries on all of them:

```js
const results = await search(db, {
  term: "Dodge challenger",
  facets: {
    brand: {
      size: 10,
      sort: "ASC",
    },
    model: {
      size: 10,
      sort: "ASC",
    },
    available: {
      size: 10,
    },
    year: {
      ranges: [
        { from: 1990, to: 1995 },
        { from: 2000, to: 2005 },
        { from: 2005, to: 2010 },
        { from: 2010, to: 2015 },
        { from: 2015, to: 2020 },
      ]
    }
  },
  limit: 2,
})
```

This will lead to the following result:

```js
{
  elapsed: 950750n,
  hits: [
    {
      id: 'a9c2a700-c23d-42d1-921d-99442d0d6af5',
      score: 8.586111395567093,
      document: {
        id: 'a9c2a700-c23d-42d1-921d-99442d0d6af5',
        brand: 'Mitsubishi',
        year: 1999,
        model: 'Challenger',
        available: false,
        used: true,
        price: 31861
      }
    },
    {
      id: '321b5c59-be55-48b9-a3d4-3e1586d1a863',
      score: 3.6680631599644267,
      document: {
        id: '321b5c59-be55-48b9-a3d4-3e1586d1a863',
        brand: 'Dodge',
        year: 2009,
        model: 'Journey',
        available: false,
        used: true,
        price: 12799
      }
    },
  ],
  count: 52,
  facets: {
    brand: { count: 2, values: { Dodge: 51, Mitsubishi: 1 } },
    model: {
      count: 26,
      values: {
        Viper: 4,
        Stratus: 4,
        'Ram 2500': 4,
        'Grand Caravan': 4,
        Dakota: 4,
        'Ram 3500': 4,
        'Dakota Club': 3,
        Journey: 2,
        Charger: 2,
        Nitro: 2
      }
    },
    available: { count: 2, values: { true: 27, false: 25 } },
    year: {
      count: 4,
      values: {
        '2000-2005': 15,
        '2005-2010': 13,
        '1990-1995': 10,
        '2010-2015': 5
      }
    }
  }
}
```

### This is a work in progress
This PR is a huge work in progress. Types are not working at their best yet, and algorithms are not optimized at all. We should also return a list of IDs to perform a "group by" operation once a user decides to enter a facet.

Please do not review yet.