### PR TITLE
fix: Vue example with wrong build script

### DIFF
--- a/examples/with-vue/package.json
+++ b/examples/with-vue/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "pnpm run build:lyra && vite",
     "build": "pnpm run build:lyra && vite build",
-    "build:lyra": "cd ../../lyra && pnpm run build && cd ../examples/with-vue",
+    "build:lyra": "cd ../../ && pnpm run build && cd ./examples/with-vue",
     "preview": "vite preview --port 4173"
   },
   "dependencies": {


### PR DESCRIPTION
Relatives paths in Vue example seemed to be wrong. I changed them and now 

**npm run dev** on vue-example folder is ok.