### PR TITLE
feat(filters): adds boolean filters

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,4 +1,4 @@
-import type { WhereFilter, FilterOperation, PropertiesSchema, Lyra } from "./types/index.js";
+import type { WhereFilter, FilterOperation, PropertiesSchema, Lyra, BooleanIndex } from "./types/index.js";
 import type { AVLNode } from "./trees/avl/node.js";
 import { greaterThan, lessThan, rangeSearch, find } from "./trees/avl/index.js";
 import { intersect } from './utils.js'
@@ -18,6 +18,14 @@ export function getWhereFiltersIDs<S extends PropertiesSchema>(filters: WhereFil
 
     if (operationKeys.length > 1) {
       throw new Error(ERRORS.INVALID_FILTER_OPERATION(operationKeys))
+    }
+
+    if (typeof operation === 'boolean') {
+      const idx = lyra.index[param] as BooleanIndex;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - this is a bug in the typescript compiler
+      const filteredIDs = idx[operation.toString() as keyof BooleanIndex];
+      filtersMap[param].push(...filteredIDs);
     }
 
     const operationOpt = operationKeys[0] as FilterOperation

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -76,6 +76,11 @@ function buildIndex<S extends PropertiesSchema>(lyra: Lyra<S>, schema: S, prefix
         lyra.index[propName] = createAVLNode<number, string[]>(0, []);
         continue;
       }
+
+      if (schema[prop] === "boolean") {
+        lyra.index[propName] = { 'true': [], 'false': [] };
+        continue;
+      }
     }
   }
 }

--- a/src/methods/insert.ts
+++ b/src/methods/insert.ts
@@ -1,4 +1,4 @@
-import type { Lyra, PropertiesSchema, ResolveSchema } from "../types/index.js";
+import type { BooleanIndex, Lyra, PropertiesSchema, ResolveSchema } from "../types/index.js";
 import type { Language, TokenizerConfigExec } from "../tokenizer/index.js";
 import type { AVLNode } from "../../src/trees/avl/node.js";
 import type { RadixNode } from "../trees/radix/node.js";
@@ -167,10 +167,14 @@ function recursiveradixInsertion<S extends PropertiesSchema>(
         schema[key] as PropertiesSchema,
       );
     }
-
     
     if (typeof doc[key] === "number" && key in schema && !isSchemaNested) {
       AVLInsert(lyra.index[propName] as AVLNode<number, string[]>, doc[key] as number, [id]);
+    }
+
+    if (typeof doc[key] === "boolean" && key in schema && !isSchemaNested) {
+      const docKey = doc[key].toString() as "true" | "false";
+      (lyra.index[propName] as BooleanIndex)[docKey].push(id);
     }
 
     if (typeof doc[key] === "string" && key in schema && !isSchemaNested) {

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -27,5 +27,7 @@ export type WhereFilter<
     ? WhereFilter<S[K], `${P}${K}.`>
     : S[K] extends "number"
       ? { [key in `${P}${K}`]?: PickOne<ComparisonOperator> }
+      : S[K] extends "boolean"
+        ? { [key in `${P}${K}`]?: boolean }
       : never
   : never;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,6 +100,11 @@ export type BM25Params = {
 
 export type TokenMap = Record<string, TokenScore[]>;
 
+export type BooleanIndex = {
+  'true': string[];
+  'false': string[];
+}
+
 type ResolveTypes<TType> = TType extends "string"
   ? string
   : TType extends "boolean"
@@ -110,7 +115,7 @@ type ResolveTypes<TType> = TType extends "string"
   ? { [P in keyof TType]: ResolveTypes<TType[P]> }
   : never;
 
-type Index = Record<string, RadixNode | AVLNode<number, string[]>>;
+type Index = Record<string, RadixNode | AVLNode<number, string[]> | BooleanIndex>;
 
 type FrequencyMap = {
   [property: string]: {

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -287,10 +287,74 @@ t.test("should throw when using multiple operators", async t => {
           gt: 4,
           // @ts-expect-error error case
           lte: 10
-        } 
+        }
       }
     });
   } catch (error) {
     t.equal(error.message, 'You can only use one operation per filter. Found 2: gt, lte');
   }
+});
+
+t.test("boolean filters", async t => {
+  t.plan(7);
+
+  const db = await create({
+    schema: {
+      id: 'string',
+      isAvailable: 'boolean',
+      name: 'string'
+    }
+  });
+
+  await insert(db, {
+    id: '1',
+    isAvailable: true,
+    name: 'coffee'
+  });
+
+  await insert(db, {
+    id: '2',
+    isAvailable: true,
+    name: 'coffee machine'
+  });
+
+  await insert(db, {
+    id: '3',
+    isAvailable: false,
+    name: 'coffee maker'
+  });
+
+  const r1 = await search(db, {
+    term: 'coffee',
+    where: {
+      isAvailable: true,
+    }
+  });
+
+  t.equal(r1.count, 2);
+  t.equal(r1.hits[0].id, '1');
+  t.equal(r1.hits[1].id, '2');
+
+  const r2 = await search(db, {
+    term: 'coffee',
+    where: {
+      isAvailable: false,
+    }
+  });
+
+  t.equal(r2.count, 1);
+  t.equal(r2.hits[0].id, '3');
+
+  await remove(db, '2');
+
+  const r3 = await search(db, {
+    term: 'coffee',
+    where: {
+      isAvailable: true,
+    }
+  });
+
+  t.equal(r3.count, 1);
+  t.equal(r3.hits[0].id, '1');
+
 });


### PR DESCRIPTION
This PR adds boolean indexing and filters to Lyra search:

```js
import { create, insert, search } from '@lyrasearch/lyra'

const db = await create({
  schema: {
    name: 'string',
    favorite: 'boolean'
  }
})

await insert(db, { ... });
await insert(db, { ... });
await insert(db, { ... });

await search({
  term: 'the prestige',
  where: {
    favorite: true
  }
})
```