### PR TITLE
feat(synonyms): adds initial synonyms interface

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -83,3 +83,9 @@ export function INVALID_BOOST_VALUE(): string {
 export function INVALID_FILTER_OPERATION(found: string[]): string {
   return `You can only use one operation per filter. Found ${found.length}: ${found.join(", ")}`;
 }
+
+export function INVALID_SYNONYM_KIND(kind: string, expected: readonly string[]): string {
+  return `Invalid synonym kind. Expected one of the following: ${expected.join(
+    ", ",
+  )}, but got: ${kind}`;
+}

--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -29,6 +29,11 @@ export async function create<S extends PropertiesSchema>(properties: Configurati
 
   validateHooks(properties.hooks);
 
+  const defaultSynonyms = {
+    oneWay: {},
+    twoWay: {},
+  }
+
   const instance: Lyra<S> = {
     defaultLanguage,
     schema: properties.schema,
@@ -41,6 +46,7 @@ export async function create<S extends PropertiesSchema>(properties: Configurati
     tokenOccurrencies: {},
     avgFieldLength: {},
     fieldLengths: {},
+    synonyms: properties.synonyms ?? defaultSynonyms,
     components: {
       elapsed: properties.components?.elapsed ?? {},
       tokenizer,

--- a/src/methods/synonyms.ts
+++ b/src/methods/synonyms.ts
@@ -1,0 +1,36 @@
+import type { Lyra, PropertiesSchema } from "../types/index.js";
+import * as ERRORS from "../errors.js";
+
+export type SynonymConfig = {
+  kind: typeof availableKinds[number];
+  word: string;
+  synonyms: string[];
+}
+
+export const availableKinds = ['oneWay', 'twoWay'] as const;
+
+export async function addSynonyms<T extends PropertiesSchema>(db: Lyra<T>, synonyms: SynonymConfig) {
+  const { kind, word, synonyms: synonymsList } = synonyms;
+
+  if (!availableKinds.includes(kind)) {
+    throw new Error(ERRORS.INVALID_SYNONYM_KIND(kind, availableKinds));
+  }
+
+  if (db.synonyms[kind][word]) {
+    db.synonyms[kind][word].push(...synonymsList);
+  } else {
+    db.synonyms[kind][word] = synonymsList;
+  }
+}
+
+export async function removeSynonyms<T extends PropertiesSchema>(db: Lyra<T>, synonyms: SynonymConfig) {
+  const { kind, word, synonyms: synonymsList } = synonyms;
+
+  if (!availableKinds.includes(kind)) {
+    throw new Error(ERRORS.INVALID_SYNONYM_KIND(kind, availableKinds));
+  }
+
+  if (db.synonyms[kind][word]) {
+    db.synonyms[kind][word] = db.synonyms[kind][word].filter(synonym => !synonymsList.includes(synonym));
+  }
+}

--- a/src/methods/synonyms.ts
+++ b/src/methods/synonyms.ts
@@ -7,6 +7,11 @@ export type SynonymConfig = {
   synonyms: string[];
 }
 
+export type ClearSynonymscConfig = {
+  kind: typeof availableKinds[number];
+  word: string;
+}
+
 export const availableKinds = ['oneWay', 'twoWay'] as const;
 
 export async function addSynonyms<T extends PropertiesSchema>(db: Lyra<T>, synonyms: SynonymConfig) {
@@ -32,5 +37,17 @@ export async function removeSynonyms<T extends PropertiesSchema>(db: Lyra<T>, sy
 
   if (db.synonyms[kind][word]) {
     db.synonyms[kind][word] = db.synonyms[kind][word].filter(synonym => !synonymsList.includes(synonym));
+  }
+}
+
+export async function clearSynonyms<T extends PropertiesSchema>(db: Lyra<T>, synonyms: ClearSynonymscConfig) {
+  const { kind, word } = synonyms;
+
+  if (!availableKinds.includes(kind)) {
+    throw new Error(ERRORS.INVALID_SYNONYM_KIND(kind, availableKinds));
+  }
+
+  if (db.synonyms[kind][word]) {
+    db.synonyms[kind][word] = [];
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,11 @@ export type PropertiesSchema = {
   [key: string]: PropertyType | PropertiesSchema;
 };
 
+export type Synonyms = {
+  oneWay: Record<string, string[]>;
+  twoWay: Record<string, string[]>;
+}
+
 export type AlgorithmsConfig = {
   intersectTokenScores: IIntersectTokenScores;
 };
@@ -55,6 +60,7 @@ export type Configuration<S extends PropertiesSchema> = {
   edge?: boolean;
   hooks?: Hooks;
   components?: Components;
+  synonyms?: Synonyms;
 };
 
 export type Data<S extends PropertiesSchema> = {
@@ -84,6 +90,7 @@ export interface Lyra<S extends PropertiesSchema> extends Data<S> {
   docsCount: number;
   avgFieldLength: Record<string, number>;
   fieldLengths: Record<string, Record<string, number>>;
+  synonyms: Synonyms;
 }
 
 export type BM25OptionalParams = {

--- a/tests/synonyms.test.ts
+++ b/tests/synonyms.test.ts
@@ -120,3 +120,24 @@ t.test("clear synonyms", async t => {
 
   t.end();
 })
+
+t.test("add synonyms with invalid kind", async t => {
+  const db = await create({
+    schema: {
+      name: "string"
+    }
+  });
+
+  try {
+    await addSynonyms(db, {
+      // @ts-expect-error error case
+      kind: "invalidKind",
+      word: "testOneWay",
+      synonyms: ["testOneWay-1", "testOneWay-2"]
+    })
+  } catch (error) {
+    t.equal(error.message, "Invalid synonym kind. Expected one of the following: oneWay, twoWay, but got: invalidKind");
+  }
+
+  t.end();
+})

--- a/tests/synonyms.test.ts
+++ b/tests/synonyms.test.ts
@@ -1,0 +1,89 @@
+import t from "tap";
+import { create } from "../src/methods/create.js";
+import { addSynonyms, removeSynonyms } from "../src/methods/synonyms.js";
+
+t.test("create Lyra instance with synonyms", async t => {
+  t.plan(2)
+
+  const db = await create({
+    schema: {
+      name: "string"
+    },
+    synonyms: {
+      oneWay: {
+        "testOneWay": ["testOneWay-1", "testOneWay-2"]
+      },
+      twoWay: {
+        "testTwoWay": ["testTwoWay-1", "testTwoWay-2"]
+      }
+    }
+  });
+
+  t.same(db.synonyms.oneWay.testOneWay, ["testOneWay-1", "testOneWay-2"]);
+  t.same(db.synonyms.twoWay.testTwoWay, ["testTwoWay-1", "testTwoWay-2"]);
+
+  t.end();
+
+});
+
+t.test("add synonyms", async t => {
+  t.plan(2)
+
+  const db = await create({
+    schema: {
+      name: "string"
+    }
+  });
+
+  addSynonyms(db, {
+    kind: "oneWay",
+    word: "testOneWay",
+    synonyms: ["testOneWay-1", "testOneWay-2"]
+  })
+
+  addSynonyms(db, {
+    kind: "twoWay",
+    word: "testTwoWay",
+    synonyms: ["testTwoWay-1", "testTwoWay-2"]
+  })
+
+  t.same(db.synonyms.oneWay.testOneWay, ["testOneWay-1", "testOneWay-2"]);
+  t.same(db.synonyms.twoWay.testTwoWay, ["testTwoWay-1", "testTwoWay-2"]);
+
+  t.end();
+})
+
+t.test("remove synonyms", async t => {
+  t.plan(2)
+
+  const db = await create({
+    schema: {
+      name: "string"
+    },
+    synonyms: {
+      oneWay: {
+        "testOneWay": ["testOneWay-1", "testOneWay-2"]
+      },
+      twoWay: {
+        "testTwoWay": ["testTwoWay-1", "testTwoWay-2"]
+      }
+    }
+  });
+
+  removeSynonyms(db, {
+    kind: "oneWay",
+    word: "testOneWay",
+    synonyms: ["testOneWay-1"]
+  })
+
+  removeSynonyms(db, {
+    kind: "twoWay",
+    word: "testTwoWay",
+    synonyms: ["testTwoWay-1"]
+  })
+
+  t.same(db.synonyms.oneWay.testOneWay, ["testOneWay-2"]);
+  t.same(db.synonyms.twoWay.testTwoWay, ["testTwoWay-2"]);
+
+  t.end();
+})

--- a/tests/synonyms.test.ts
+++ b/tests/synonyms.test.ts
@@ -1,6 +1,6 @@
 import t from "tap";
 import { create } from "../src/methods/create.js";
-import { addSynonyms, removeSynonyms } from "../src/methods/synonyms.js";
+import { addSynonyms, removeSynonyms, clearSynonyms } from "../src/methods/synonyms.js";
 
 t.test("create Lyra instance with synonyms", async t => {
   t.plan(2)
@@ -84,6 +84,39 @@ t.test("remove synonyms", async t => {
 
   t.same(db.synonyms.oneWay.testOneWay, ["testOneWay-2"]);
   t.same(db.synonyms.twoWay.testTwoWay, ["testTwoWay-2"]);
+
+  t.end();
+})
+
+t.test("clear synonyms", async t => {
+  t.plan(2)
+
+  const db = await create({
+    schema: {
+      name: "string"
+    },
+    synonyms: {
+      oneWay: {
+        "testOneWay": ["testOneWay-1", "testOneWay-2"]
+      },
+      twoWay: {
+        "testTwoWay": ["testTwoWay-1", "testTwoWay-2"]
+      }
+    }
+  });
+
+  clearSynonyms(db, {
+    kind: "oneWay",
+    word: "testOneWay"
+  })
+
+  clearSynonyms(db, {
+    kind: "twoWay",
+    word: "testTwoWay"
+  })
+
+  t.same(db.synonyms.oneWay.testOneWay, []);
+  t.same(db.synonyms.twoWay.testTwoWay, []);
 
   t.end();
 })


### PR DESCRIPTION
This is the initial implementation of the `synonyms` features for Lyra.
Will be released as part of the `Orama` rebrand ([learn more here](https://micheleriva.medium.com/ive-founded-a-company-introducing-oramasearch-inc-f69121b6b1c3)) with the `v1.0.0` release.

## API Design

You can initialize synonyms during a new database creation:

```js
import { create } from "@lyrasearch/lyra"; 

  const db = await create({
    schema: {
      name: "string"
    },
    synonyms: {
      // when searching for "phone", you'll also get results for "iphone", "smartphone", and "telephone"
      // when searching for "iphone", you won't get any synonym-related search result
      oneWay: {
        "phone": ["iphone", "smartphone", "telephone"]
      },
      // when searching for "shirt", you'll also get results for "t-shirt" and "jacket"
     // the same applies the other way around; when searching for "t-shirt" or "jacket", you'll also find results for "shirt"
      twoWay: {
        "shirt": ["t-shirt", "jacket"]
      }
    }
  });
```

You can also add and remove synonyms using the two new `addSynonyms`, `removeSynonyms`, and `clearSynonyms` functions:

```js
import { addSynonyms, removeSynonyms, clearSynonyms } from "@lyrasearch/lyra";

await addSynonyms(db, {
  kind: "oneWay",
  word: "shirt",
  synonyms: ["t-shirt", "jacket"]
});

await removeSynonyms(db, {
  kind: "oneWay",
  word: "shirt",
  synonyms: ["jacket"] // will only remove the "jacket" synonym
});

await clearSynonyms(db, {
  kind: "oneWay",
  word: "shirt" // will remove all the "shirt" synonyms
});
```

Still a work in progress.